### PR TITLE
Fixing some simple timezone issues in tests

### DIFF
--- a/ui/test/unit/common/domain/services/programService.spec.js
+++ b/ui/test/unit/common/domain/services/programService.spec.js
@@ -315,9 +315,9 @@ describe('programService', function () {
         expect(mockHttp.post.calls.mostRecent().args[0]).toEqual(Bahmni.Common.Constants.programEnrollPatientUrl);
         expect(mockHttp.post.calls.mostRecent().args[1].patient).toEqual(patientUuid);
         expect(mockHttp.post.calls.mostRecent().args[1].program).toEqual(programUuid);
-        expect(mockHttp.post.calls.mostRecent().args[1].dateEnrolled).toEqual("2015-12-11T12:04:23+0530");
+        expect(moment(mockHttp.post.calls.mostRecent().args[1].dateEnrolled).isSame(moment("2015-12-11T12:04:23+0530"))).toBe(true);
         expect(mockHttp.post.calls.mostRecent().args[1].states[0].state).toEqual(workflowUuid);
-        expect(mockHttp.post.calls.mostRecent().args[1].states[0].startDate).toEqual("2015-12-11T12:04:23+0530");
+        expect(moment(mockHttp.post.calls.mostRecent().args[1].states[0].startDate).isSame(moment("2015-12-11T12:04:23+0530"))).toBe(true);
         expect(mockHttp.post.calls.mostRecent().args[1].attributes).toEqual([ { attributeType : { uuid : '82325788-3f10-11e4-adec-0800271c1b75' }, value : 'alps' } ]);
     })
 
@@ -328,7 +328,7 @@ describe('programService', function () {
         programService.endPatientProgram(patientProgramUuid, dateCompleted, outcome);
 
         expect(mockHttp.post.calls.mostRecent().args[0]).toEqual(Bahmni.Common.Constants.programEnrollPatientUrl + "/" + patientProgramUuid);
-        expect(mockHttp.post.calls.mostRecent().args[1].dateCompleted).toEqual("2015-12-11T12:04:23+0530");
+        expect(moment(mockHttp.post.calls.mostRecent().args[1].dateCompleted).isSame(moment("2015-12-11T12:04:23+0530"))).toBe(true);
         expect(mockHttp.post.calls.mostRecent().args[1].outcome).toEqual(outcome);
     });
 

--- a/ui/test/unit/registration/mappers/openmrsPatientMapper.spec.js
+++ b/ui/test/unit/registration/mappers/openmrsPatientMapper.spec.js
@@ -109,7 +109,7 @@ describe('patientMapper', function () {
         expect(patient.address.cityVillage).toBe(openmrsPatient.patient.person.preferredAddress.cityVillage);
         expect(patient.address.countyDistrict).toBe(openmrsPatient.patient.person.preferredAddress.countyDistrict);
         expect(patient.address.stateProvince).toBe(openmrsPatient.patient.person.preferredAddress.stateProvince);
-        expect(patient.date.toString()).toBe(moment("1999-01-01").toDate().toString());
+        expect(moment(patient.date).zone(0).isSame(moment("1998-12-31T18:30:00.000+0000"))).toBe(true);
         var urlParts = patient.image.split('?');
         expect(urlParts.length).toBe(2);
         expect(urlParts[0]).toBe("/patient_images/" + openmrsPatient.patient.uuid + ".jpeg");


### PR DESCRIPTION
This commit fixes a few issues experience when running the test in the AEST timezone at around 20:00.

There are three other errors that I am not convinced are errors in the unit tests:

```
PhantomJS 1.9.8 (Mac OS X 0.0.0) patientMapper should map birth date in dd-mm-yyyy format FAILED
	Expected '2016-01-15' to equal '2016-01-14'.
	Error: Expected '2016-01-15' to equal '2016-01-14'.
	    at /Users/mnewman/projects/bahmni/openmrs-module-bahmniapps/ui/test/unit/registration/mappers/openmrsPatientMapper.spec.js:127
PhantomJS 1.9.8 (Mac OS X 0.0.0) patientMapper should map registration date FAILED
	Expected '2016-01-15' to equal '2016-01-14'.
	Error: Expected '2016-01-15' to equal '2016-01-14'.
	    at /Users/mnewman/projects/bahmni/openmrs-module-bahmniapps/ui/test/unit/registration/mappers/openmrsPatientMapper.spec.js:140
PhantomJS 1.9.8 (Mac OS X 0.0.0) patientMapper should populate birthdate and age if birthdate is not estimated FAILED
	Expected '2013-09-20' to equal '2013-09-19'.
	Error: Expected '2013-09-20' to equal '2013-09-19'.
	    at /Users/mnewman/projects/bahmni/openmrs-module-bahmniapps/ui/test/unit/registration/mappers/openmrsPatientMapper.spec.js:155
```

but I will look into these more and might need some feedback on what the expected behaviour is.
