### PR TITLE
Charlie | Check dates against local timezone in unit test

### DIFF
--- a/ui/test/unit/common/domain/services/programService.spec.js
+++ b/ui/test/unit/common/domain/services/programService.spec.js
@@ -604,8 +604,8 @@ describe('programService', function () {
             "attributes": attributes,
             "states": [],
             "outcome": null,
-            "dateCompleted": "2016-01-12T05:30:00+0530",
-            "dateEnrolled": "2016-01-01T00:00:00+0530",
+            "dateCompleted": moment("2016-01-12T05:30:00+0530").format('YYYY-MM-DDTHH:mm:ssZZ'),
+            "dateEnrolled": moment("2016-01-01T00:00:00").format('YYYY-MM-DDTHH:mm:ssZZ'),
             "uuid": "Some UUID"
 
         };


### PR DESCRIPTION
Update unit test to check dates against local timezone.

Otherwise, tests fail in timezones other than IST. For example, when run in Australia, programService test updatePatientProgram expects dateEnrolled : '2016-01-01T00:00:00+1000' but the returned value is dateEnrolled : '2016-01-01T00:00:00+0530'.