### PR TITLE
registration search: strip registration prefix from registration number if present

### DIFF
--- a/ui/app/registration/controllers/searchController.js
+++ b/ui/app/registration/controllers/searchController.js
@@ -197,6 +197,16 @@ angular.module('bahmni.registration')
                 $scope.results = [];
 
                 var patientIdentifier = $scope.searchParameters.registrationNumber;
+
+                // strip off the identifier prefix from the identifier itself if it exists
+                $scope.identifierSources.forEach(function (identifierSource) {
+                    var regex = new RegExp('^' + identifierSource.prefix, 'i');
+                    if (regex.test(patientIdentifier)) {
+                        patientIdentifier = patientIdentifier.replace(regex, '');
+                        $scope.searchParameters.identifierPrefix = identifierSource;  // make sure that the identifier prefix search parameter is set to the prefix we found
+                    }
+                });
+
                 preferences.identifierPrefix = $scope.searchParameters.identifierPrefix ? $scope.searchParameters.identifierPrefix.prefix : "";
 
                 $location.search({

--- a/ui/test/unit/registration/controllers/searchPatientController.spec.js
+++ b/ui/test/unit/registration/controllers/searchPatientController.spec.js
@@ -268,6 +268,37 @@ describe('SearchPatientController', function () {
             expect(patientResource.search).not.toHaveBeenCalled();
         });
 
+        it('should strip prefix from registrationNumber if present', function () {
+            scope.searchParameters.identifierPrefix = {};
+            scope.searchParameters.identifierPrefix.prefix = "GAN";
+            scope.searchParameters.registrationNumber = "gan20001";  // match should case-insensitive
+            var defaultSearchAddressField = undefined;
+            scope.searchById();
+
+            expect(patientResource.search).toHaveBeenCalledWith(undefined, "20001", "GAN", defaultSearchAddressField, undefined, undefined, undefined, undefined, undefined, undefined);
+        });
+
+        it('should strip prefix from registrationNumber even if not selected prefix', function () {
+            scope.searchParameters.identifierPrefix = {};
+            scope.searchParameters.identifierPrefix.prefix = "GAN";
+            scope.searchParameters.registrationNumber = "sem20001";  // match should case-insensitive
+            var defaultSearchAddressField = undefined;
+            scope.searchById();
+
+            expect(patientResource.search).toHaveBeenCalledWith(undefined, "20001", "SEM", defaultSearchAddressField, undefined, undefined, undefined, undefined, undefined, undefined);
+        });
+
+        it('should not strip prefix from registrationNumber if found elsewhere than as a prefix', function () {
+            scope.searchParameters.identifierPrefix = {};
+            scope.searchParameters.identifierPrefix.prefix = "GAN";
+            scope.searchParameters.registrationNumber = "20001gan";
+            var defaultSearchAddressField = undefined;
+            scope.searchById();
+
+            expect(patientResource.search).toHaveBeenCalledWith(undefined, "20001gan", "GAN", defaultSearchAddressField, undefined, undefined, undefined, undefined, undefined, undefined);
+        });
+
+
         describe("on success", function () {
             beforeEach(function () {
                 scope.searchParameters.identifierPrefix = {};


### PR DESCRIPTION

See:

https://talk.openmrs.org/t/searching-for-full-patient-identifier-incl-prefix-during-registration/3809