### PR TITLE
#1755: Ability to configure forward-url on click of Save on Registration visit page

### DIFF
--- a/ui/app/registration/controllers/visitController.js
+++ b/ui/app/registration/controllers/visitController.js
@@ -163,17 +163,21 @@ angular.module('bahmni.registration')
             };
             //End :: Registration Page validation
 
-            var reload = function () {
-                $state.transitionTo($state.current, $state.params, {
+            var afterSave = function () {
+
+                var nextState = appService.getAppDescriptor().getConfigValue('afterVisitSaveTransitionToState');
+
+                $state.transitionTo(nextState ? nextState : $state.current, $state.params, {
                     reload: true,
                     inherit: false,
                     notify: true
                 });
+
                 messagingService.showMessage('info', 'REGISTRATION_LABEL_SAVED');
             };
 
             $scope.submit = function () {
-                return validate().then(save).then(reload);
+                return validate().then(save).then(afterSave);
             };
 
             $scope.today = function () {

--- a/ui/test/unit/registration/controllers/visitController.spec.js
+++ b/ui/test/unit/registration/controllers/visitController.spec.js
@@ -179,8 +179,27 @@ describe('VisitController', function () {
             scope.patient = {uuid: "21308498-2502-4495-b604-7b704a55522d"};
         });
 
-        it("should validate save and reload current page", function (done) {
+        it("should validate save and reload current page if afterVisitSaveTransitionToState not specified", function (done) {
             state.expectTransitionTo(state.current);
+            var submit = scope.submit();
+            submit.then(function (response) {
+                expect(encounterService.create).toHaveBeenCalled();
+                expect(messagingService.showMessage).toHaveBeenCalledWith('info', 'REGISTRATION_LABEL_SAVED');
+                state.ensureAllTransitionsHappened();
+                done();
+            });
+        });
+
+        it("should validate save and redirect to state specify by afterVisitSaveTransitionToState", function (done) {
+            appDescriptor.getConfigValue.and.callFake(function(value) {
+                if (value == 'afterVisitSaveTransitionToState') {
+                    return "search";
+                }
+                else {
+                    return "";
+                }
+            });
+            state.expectTransitionTo("search");
             var submit = scope.submit();
             submit.then(function (response) {
                 expect(encounterService.create).toHaveBeenCalled();


### PR DESCRIPTION

See:

https://bahmni.mingle.thoughtworks.com/projects/bahmni_emr/cards/1755

and

 https://talk.openmrs.org/t/save-visit-details-and-forward-url/6340/3

I've added a new  registration app config parameter "afterVisitSaveTransitionToState" where you can specify which state to transition to after saving.  If the parameter is not specified, the current behavior (stay on same page) is maintained.