### PR TITLE
Ability to hide birth time on registration page

### DIFF
--- a/ui/app/registration/controllers/patientCommonController.js
+++ b/ui/app/registration/controllers/patientCommonController.js
@@ -7,6 +7,8 @@ angular.module('bahmni.registration')
             var autoCompleteFields = appService.getAppDescriptor().getConfigValue("autoCompleteFields", []);
             var showCasteSameAsLastNameCheckbox = appService.getAppDescriptor().getConfigValue("showCasteSameAsLastNameCheckbox");
             $scope.showMiddleName = appService.getAppDescriptor().getConfigValue("showMiddleName");
+            $scope.showBirthTime = appService.getAppDescriptor().getConfigValue("showBirthTime") != null
+                ? appService.getAppDescriptor().getConfigValue("showBirthTime") : true;  // show birth time by default
             $scope.genderCodes = Object.keys($rootScope.genderMap);
             $scope.dobMandatory = appService.getAppDescriptor().getConfigValue("dobMandatory") || false;
 

--- a/ui/app/registration/views/dob.html
+++ b/ui/app/registration/views/dob.html
@@ -22,10 +22,10 @@
             <input type="checkbox" ng-model="patient.birthdateEstimated" class="estimate-check">
         </div>
     </div>
-    <div class="field-attribute">
+    <div ng-show="::showBirthTime" class="field-attribute">
         <label for="birthtime">{{ ::'REGISTRATION_LABEL_BIRTH_TIME' | translate}}</label>
     </div>
-    <div class="field-value">
+    <div ng-show="::showBirthTime" class="field-value">
         <input id="birthtime" type="time" ng-model="patient.birthtime">
     </div>
 </article>

--- a/ui/test/unit/registration/controllers/patientCommonController.spec.js
+++ b/ui/test/unit/registration/controllers/patientCommonController.spec.js
@@ -2,7 +2,7 @@
 
 describe('PatientCommonController', function () {
 
-    var $aController, $httpBackend,scope;
+    var $aController, $httpBackend, scopeMock, rootScopeMock, patientAttributeServiceMock, spinnerMock, appServiceMock;
 
     beforeEach(module('bahmni.registration'));
 
@@ -10,13 +10,67 @@ describe('PatientCommonController', function () {
         inject(function ($controller, _$httpBackend_,$rootScope) {
             $aController = $controller;
             $httpBackend = _$httpBackend_;
-            scope = $rootScope.$new();
+            rootScopeMock = $rootScope;
+            scopeMock = $rootScope.$new();
         })
     );
+
+    beforeEach(function() {
+        patientAttributeServiceMock = jasmine.createSpyObj('patientAttributeServiceMock', ['']);
+        spinnerMock = jasmine.createSpyObj('spinnerMock', ['forPromise']);
+        appServiceMock = jasmine.createSpyObj('appServiceMock', ['getAppDescriptor']);
+        rootScopeMock.genderMap = {}
+    })
 
     it("should make calls for reason for death global property and concept sets", function () {
         $httpBackend.expectGET(Bahmni.Common.Constants.globalPropertyUrl);
         $httpBackend.expectGET(Bahmni.Common.Constants.conceptUrl);
+    });
+
+    it("showBirthTime should be true by default", function () {
+
+        appServiceMock.getAppDescriptor = function() {
+            return {
+                getConfigValue: function(config) {
+                    return null;
+                }
+            };
+        };
+
+        $aController('PatientCommonController', {
+            $scope: scopeMock,
+            $rootScope: rootScopeMock,
+            http: $httpBackend,
+            patientAttributeService: patientAttributeServiceMock,
+            spinner: spinnerMock,
+            appService: appServiceMock
+        });
+
+        expect(scopeMock.showBirthTime).toBe(true);
+    });
+
+    it("showBirthTime should be false if set false", function () {
+
+        appServiceMock.getAppDescriptor = function() {
+            return {
+                getConfigValue: function(config) {
+                    if (config == "showBirthTime") {
+                        return false;
+                    }
+                }
+            };
+        };
+
+        $aController('PatientCommonController', {
+            $scope: scopeMock,
+            $rootScope: rootScopeMock,
+            http: $httpBackend,
+            patientAttributeService: patientAttributeServiceMock,
+            spinner: spinnerMock,
+            appService: appServiceMock
+        });
+
+        expect(scopeMock.showBirthTime).toBe(false);
     });
 
 });


### PR DESCRIPTION

This adds the ability show or hide the birth time on the main registration page in a similar manner to the current "showMiddleName" functionality.

For backwards compatibility, defaults to "true"

