### PR TITLE
#1755: Ability to configure forward-url on click of Save on Registration visit page

### DIFF
--- a/ui/app/registration/controllers/visitController.js
+++ b/ui/app/registration/controllers/visitController.js
@@ -166,7 +166,7 @@ angular.module('bahmni.registration')
             var afterSave = function () {
                 var forwardUrl = appService.getAppDescriptor().getConfigValue("afterVisitSaveForwardUrl");
                 if (forwardUrl != null) {
-                    $location.url(appService.getAppDescriptor().formatUrl(forwardUrl, {'patientUuid': patientUuid}));
+                    $window.location.href = appService.getAppDescriptor().formatUrl(forwardUrl, {'patientUuid': patientUuid});
                 }
                 else {
                     $state.transitionTo($state.current, $state.params, {

--- a/ui/app/registration/controllers/visitController.js
+++ b/ui/app/registration/controllers/visitController.js
@@ -163,17 +163,23 @@ angular.module('bahmni.registration')
             };
             //End :: Registration Page validation
 
-            var reload = function () {
-                $state.transitionTo($state.current, $state.params, {
-                    reload: true,
-                    inherit: false,
-                    notify: true
-                });
+            var afterSave = function () {
+                var forwardUrl = appService.getAppDescriptor().getConfigValue("afterVisitSaveForwardUrl");
+                if (forwardUrl != null) {
+                    $location.url(appService.getAppDescriptor().formatUrl(forwardUrl, {'patientUuid': patientUuid}));
+                }
+                else {
+                    $state.transitionTo($state.current, $state.params, {
+                        reload: true,
+                        inherit: false,
+                        notify: true
+                    });
+                }
                 messagingService.showMessage('info', 'REGISTRATION_LABEL_SAVED');
             };
 
             $scope.submit = function () {
-                return validate().then(save).then(reload);
+                return validate().then(save).then(afterSave);
             };
 
             $scope.today = function () {

--- a/ui/test/unit/registration/controllers/visitController.spec.js
+++ b/ui/test/unit/registration/controllers/visitController.spec.js
@@ -107,7 +107,7 @@ describe('VisitController', function () {
         patientService = jasmine.createSpyObj('patientService', ['get','updateImage']);
         visitService = jasmine.createSpyObj('visitService', ['search', 'endVisit', 'getVisitSummary']);
         appService = jasmine.createSpyObj('appService', ['getDescription', 'getAppDescriptor']);
-        appDescriptor = jasmine.createSpyObj('appDescriptor', ['getConfigValue', 'getExtensions']);
+        appDescriptor = jasmine.createSpyObj('appDescriptor', ['getConfigValue', 'getExtensions', 'formatUrl']);
         appService.getAppDescriptor.and.returnValue(appDescriptor);
         appDescriptor.getExtensions.and.returnValue([]);
         patientMapper = jasmine.createSpyObj('patientMapper', ['map']);
@@ -179,13 +179,37 @@ describe('VisitController', function () {
             scope.patient = {uuid: "21308498-2502-4495-b604-7b704a55522d"};
         });
 
-        it("should validate save and reload current page", function (done) {
+        it("should validate save and reload current page if afterVisitSaveForwardUrl not specified", function (done) {
             state.expectTransitionTo(state.current);
             var submit = scope.submit();
             submit.then(function (response) {
                 expect(encounterService.create).toHaveBeenCalled();
                 expect(messagingService.showMessage).toHaveBeenCalledWith('info', 'REGISTRATION_LABEL_SAVED');
                 state.ensureAllTransitionsHappened();
+                done();
+            });
+        });
+
+        it("should validate save and redirect to url specify by afterVisitSaveForwardUrl", function (done) {
+
+            appDescriptor.getConfigValue.and.callFake(function(value) {
+                if (value == 'afterVisitSaveForwardUrl') {
+                    return "/search";
+                }
+                else {
+                    return "";
+                }
+            });
+
+            appDescriptor.formatUrl.and.callFake(function(value) {
+                return value;
+            });
+
+            var submit = scope.submit();
+            submit.then(function (response) {
+                expect(encounterService.create).toHaveBeenCalled();
+                expect(messagingService.showMessage).toHaveBeenCalledWith('info', 'REGISTRATION_LABEL_SAVED');
+                expect(location.url).toHaveBeenCalledWith("/search");
                 done();
             });
         });


### PR DESCRIPTION
This is an updated pull request based on feedback from previous pull request.  I have changed the "afterVisitSaveTransitionToSave" configuration parameter to "afterVisitSaveForwardUrl", which I agree is more flexible and closer in line with what we are doing elsewhere.

However, I kept this in the registration app.json, not extension,json, because this is not an extension ponit we are configuring, and it seemed needlessly complex just to add an extension point for this.  I follow the pattern for "searchByIdForwardUrl", which is in app.json, not extension.  I also noted that other "forward" urls are configured in app.json in other locations, for instance the ADT app.

Let me know if you have further questions/comments, thanks!
Mark
