### PR TITLE
add grunt clean:coverage task

### DIFF
--- a/ui/Gruntfile.js
+++ b/ui/Gruntfile.js
@@ -74,6 +74,9 @@ module.exports = function (grunt) {
                     }
                 ]
             },
+            coverage: [
+                'coverage'
+            ],
             debug: [
                 '<%= yeoman.app %>/styles/*.css'
             ]


### PR DESCRIPTION
If we don’t clean the coverage directory, we can get errors like this:

    Running "coverage" task
    Fatal error: Cannot read property 'length' of undefined

This is due to coverage reports being out of sync, as described in this
issue against the grunt-istanbul-coverage project:
https://github.com/daniellmb/grunt-istanbul-coverage/issues/10