### PR TITLE
move `bower install` into an npm `postinstall` script to simplify environment setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ install:
   - gem install compass
   - cd ui && npm install
   - cat npm-debug.log || true
-  - bower install
 
 script: grunt
 

--- a/ui/Gruntfile.js
+++ b/ui/Gruntfile.js
@@ -548,7 +548,6 @@ module.exports = function (grunt) {
 
     grunt.registerTask('bundle', [
         'npm-install',
-        'bower-install',
         'eslint',
         'clean:dist',
         'compass:dist',
@@ -570,8 +569,15 @@ module.exports = function (grunt) {
 
     grunt.registerTask('build', [
         'npm-install',
+<<<<<<< 3be2f681483155d3690aecce0c56bfe7c04bf56d
         'bower-install',
         'eslint',
+||||||| merged common ancestors
+        'bower-install',
+        'jshint',
+=======
+        'jshint',
+>>>>>>> EP: remove calls to bower which are no unnecissary. task 'bower-install' is now unused within this project
         'dist'
     ]);
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,6 +14,7 @@
         "eslint-plugin-angular": "^1.4.1",
         "eslint-plugin-promise": "^3.3.0",
         "eslint-plugin-standard": "^2.0.1",
+        "bower": "^1.7.9",
         "grunt": "~0.4.5",
         "grunt-contrib-clean": "^0.5.0",
         "grunt-comment-toggler": "^0.2.2",
@@ -46,7 +47,8 @@
         "react-dom": "^15.2.1"
     },
     "scripts": {
-        "test": "karma start test/config/karma.conf.js"
+        "test": "karma start test/config/karma.conf.js",
+        "postinstall": "./node_modules/.bin/bower --allow-root install"
     },
     "repository": {
         "type": "git",

--- a/ui/scripts/package.sh
+++ b/ui/scripts/package.sh
@@ -11,7 +11,6 @@ mkdir -p $ROOT_DIR/target
 rm -rf $ROOT_DIR/target/${ZIP_FILE_NAME}*.zip
 
 npm install
-bower install
 
 if [ $(pgrep Xvfb) ]; then
     XVFB_PID=$(pgrep Xvfb)


### PR DESCRIPTION
this casues bower install to be triggered by `npm install`. 

This saves us having to run both `npm install` and `bower install` when package changes are made. 

`./node_modules/.bin/bower` is used so that the developer doesn't need`bower` installed globally.

I left in `grunt bower-install` because I don't know if it's being called externally to this project.
