### PR TITLE
Travis build config changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: node_js
 node_js: "6"
 
 before_install:
-  - "npm config set spin false"
+  - if [[ `npm -v` == 3.10.8 ]]; then npm i -g npm@3.10.7; fi
+  - npm --version
+  - npm config set spin false
 
   # https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
   - export DISPLAY=:99.0
@@ -14,6 +16,15 @@ install:
   - npm install -g grunt-cli
   - gem install compass
   - cd ui && npm install
+  - cat npm-debug.log || true
   - bower install
 
 script: grunt
+
+cache:
+  directories:
+  - ui/node_modules
+  - ui/app/components
+
+notifications:
+  email: false

--- a/ui/test/config/karma.conf.js
+++ b/ui/test/config/karma.conf.js
@@ -84,7 +84,7 @@ module.exports = function (config) {
             'app/common/offline/dbservices/dao/labOrderResultsDbService.js',
             'test/integration/dbServices/dao/labOrderResultsDbService.spec.js'
         ],
-        reporters: ['junit', 'progress', 'coverage'],
+        reporters: ['junit', (process.env.CI === 'true' ? 'dots' : 'progress'), 'coverage'],
         preprocessors: {
             'app/admin/**/*.js': ['coverage'],
             'app/adt/**/*.js': ['coverage'],


### PR DESCRIPTION
A few changes:

* Works around npm/npm#14042 using
https://github.com/travis-ci/travis-ci/issues/4653#issuecomment-194051953
* Print out the npm debug log for when npm fails
* Cache the npm and bower directories to speed up the build
* Explicitly disable email notifications
* Use 'dots' reporter rather than 'progress' for Karma to keep console output smaller