### PR TITLE
Fixes for ESLint angular/di rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -37,6 +37,7 @@ globals:
 
 rules:
   angular/controller-as: off
+  angular/di: [error, array]
   indent: [error, 4]
   quotes: off
 
@@ -61,7 +62,6 @@ rules:
   angular/window-service: warn
   standard/object-curly-even-spacing: warn
   no-unneeded-ternary: warn
-  angular/di: [warn, array]
   angular/angularelement: warn
   angular/json-functions: warn
   angular/no-service-method: warn

--- a/ui/app/admin/app.js
+++ b/ui/app/admin/app.js
@@ -51,7 +51,7 @@ angular.module('admin')
             });
             $httpProvider.defaults.headers.common['Disable-WWW-Authenticate'] = true;
         }
-    ]).run(function ($rootScope, $templateCache) {
+    ]).run(['$rootScope', '$templateCache', function ($rootScope, $templateCache) {
         // Disable caching view template partials
         $rootScope.$on('$viewContentLoaded', $templateCache.removeAll);
-    });
+    }]);

--- a/ui/app/adt/controllers/bedManagementController.js
+++ b/ui/app/adt/controllers/bedManagementController.js
@@ -2,7 +2,7 @@
 
 angular.module('bahmni.adt')
     .controller('BedManagementController', [
-        '$scope', '$rootScope', '$stateParams', 'spinner', 'WardService', 'backlinkService',
+        '$scope', '$rootScope', '$stateParams', 'spinner', 'wardService', 'backlinkService',
         function ($scope, $rootScope, $stateParams, spinner, wardService, backlinkService) {
             $scope.wards = null;
             $scope.encounterUuid = $stateParams.encounterUuid;

--- a/ui/app/adt/controllers/wardController.js
+++ b/ui/app/adt/controllers/wardController.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.adt')
-    .controller('WardController', ['$scope', '$rootScope', '$window', 'spinner', 'WardService', 'bedManagementService', 'userService',
+    .controller('WardController', ['$scope', '$rootScope', '$window', 'spinner', 'wardService', 'bedManagementService', 'userService',
         function ($scope, $rootScope, $window, spinner, wardService, bedManagementService, userService) {
             var init = function () {
                 if ($scope.readOnly) {

--- a/ui/app/adt/controllers/wardController.js
+++ b/ui/app/adt/controllers/wardController.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.adt')
-    .controller('WardController', ['$scope', '$rootScope', '$window', 'spinner', 'WardService', 'BedManagementService', 'userService',
+    .controller('WardController', ['$scope', '$rootScope', '$window', 'spinner', 'WardService', 'bedManagementService', 'userService',
         function ($scope, $rootScope, $window, spinner, wardService, bedManagementService, userService) {
             var init = function () {
                 if ($scope.readOnly) {

--- a/ui/app/adt/controllers/wardLayoutController.js
+++ b/ui/app/adt/controllers/wardLayoutController.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.adt')
-    .controller('WardLayoutController', ['$scope', '$rootScope', '$window', 'spinner', 'WardService', 'bedManagementService', 'bedService', 'messagingService', 'appService', '$document', '$element',
+    .controller('WardLayoutController', ['$scope', '$rootScope', '$window', 'spinner', 'wardService', 'bedManagementService', 'bedService', 'messagingService', 'appService', '$document', '$element',
         function ($scope, $rootScope, $window, spinner, wardService, bedManagementService, bedService, messagingService, appService, $document, $element) {
             $scope.selectedBed = null;
             var maxPatientsConfig = appService.getAppDescriptor().getConfig("maxPatientsPerBed");

--- a/ui/app/adt/controllers/wardLayoutController.js
+++ b/ui/app/adt/controllers/wardLayoutController.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.adt')
-    .controller('WardLayoutController', ['$scope', '$rootScope', '$window', 'spinner', 'WardService', 'BedManagementService', 'bedService', 'messagingService', 'appService', '$document', '$element',
+    .controller('WardLayoutController', ['$scope', '$rootScope', '$window', 'spinner', 'WardService', 'bedManagementService', 'bedService', 'messagingService', 'appService', '$document', '$element',
         function ($scope, $rootScope, $window, spinner, wardService, bedManagementService, bedService, messagingService, appService, $document, $element) {
             $scope.selectedBed = null;
             var maxPatientsConfig = appService.getAppDescriptor().getConfig("maxPatientsPerBed");

--- a/ui/app/adt/controllers/wardListController.js
+++ b/ui/app/adt/controllers/wardListController.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.adt')
-    .controller('WardListController', ['$scope', 'QueryService', 'spinner', '$q', '$window', '$stateParams', 'appService', '$rootScope',
+    .controller('WardListController', ['$scope', 'queryService', 'spinner', '$q', '$window', '$stateParams', 'appService', '$rootScope',
         function ($scope, queryService, spinner, $q, $window, $stateParams, appService, $rootScope) {
             $scope.gotoPatientDashboard = function (patientUuid, visitUuid) {
                 var options = $.extend({}, $stateParams);

--- a/ui/app/adt/controllers/wardsController.js
+++ b/ui/app/adt/controllers/wardsController.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.adt')
-    .controller('WardsController', ['$scope', '$rootScope', '$window', '$document', 'spinner', 'WardService',
+    .controller('WardsController', ['$scope', '$rootScope', '$window', '$document', 'spinner', 'wardService',
         function ($scope, $rootScope, $window, $document, spinner, wardService) {
             $scope.wards = null;
 

--- a/ui/app/adt/services/bedManagementService.js
+++ b/ui/app/adt/services/bedManagementService.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.adt')
-    .service('BedManagementService', [function () {
+    .service('bedManagementService', [function () {
         var maxX = 1;
         var maxY = 1;
         var minX = 1;

--- a/ui/app/adt/services/queryService.js
+++ b/ui/app/adt/services/queryService.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.adt')
-    .service('QueryService', ['$http', function ($http) {
+    .service('queryService', ['$http', function ($http) {
         this.getResponseFromQuery = function (params) {
             return $http.get(Bahmni.Common.Constants.sqlUrl, {
                 method: "GET",

--- a/ui/app/adt/services/wardService.js
+++ b/ui/app/adt/services/wardService.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.adt')
-    .service('WardService', ['$http', function ($http) {
+    .service('wardService', ['$http', function ($http) {
         this.bedsForWard = function (uuid) {
             return $http.get(Bahmni.ADT.Constants.admissionLocationUrl + uuid, {
                 method: "GET",

--- a/ui/app/clinical/app.js
+++ b/ui/app/clinical/app.js
@@ -224,8 +224,8 @@ angular.module('consultation')
                     cachebuster: null
                 },
                 resolve: {
-                    activeDrugOrders: function (TreatmentService, $stateParams) {
-                        return TreatmentService.getActiveDrugOrders($stateParams.patientUuid, $stateParams.dateEnrolled, $stateParams.dateCompleted);
+                    activeDrugOrders: function (treatmentService, $stateParams) {
+                        return treatmentService.getActiveDrugOrders($stateParams.patientUuid, $stateParams.dateEnrolled, $stateParams.dateCompleted);
                     }
                 },
                 views: {

--- a/ui/app/clinical/common/offline/offlineTreatmentService.js
+++ b/ui/app/clinical/common/offline/offlineTreatmentService.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.clinical')
-    .factory('TreatmentService', ['$q', 'appService', 'offlineDbService', 'offlineService', 'androidDbService',
+    .factory('treatmentService', ['$q', 'appService', 'offlineDbService', 'offlineService', 'androidDbService',
         function ($q, appService, offlineDbService, offlineService, androidDbService) {
             if (offlineService.isAndroidApp()) {
                 offlineDbService = androidDbService;

--- a/ui/app/clinical/common/services/clinicalAppConfigService.js
+++ b/ui/app/clinical/common/services/clinicalAppConfigService.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.clinical')
-    .service('clinicalAppConfigService', ['appService', 'urlHelper', '$stateParams', function (appService, urlHelper, stateParams) {
+    .service('clinicalAppConfigService', ['appService', 'urlHelper', '$stateParams', function (appService, urlHelper, $stateParams) {
         this.getTreatmentActionLink = function () {
             return appService.getAppDescriptor().getExtensions("org.bahmni.clinical.treatment.links", "link") || [];
         };
@@ -53,14 +53,14 @@ angular.module('bahmni.clinical')
         this.getConsultationBoardLink = function () {
             var allBoards = this.getAllConsultationBoards();
             var defaultBoard = _.find(allBoards, 'default');
-            if (stateParams.programUuid) {
-                var programParams = "?programUuid=" + stateParams.programUuid +
-                    "&enrollment=" + stateParams.enrollment +
-                    "&dateEnrolled=" + stateParams.dateEnrolled +
-                    "&dateCompleted=" + stateParams.dateCompleted;
-                return "/" + stateParams.configName + urlHelper.getPatientUrl() + "/" + defaultBoard.url + programParams;
+            if ($stateParams.programUuid) {
+                var programParams = "?programUuid=" + $stateParams.programUuid +
+                    "&enrollment=" + $stateParams.enrollment +
+                    "&dateEnrolled=" + $stateParams.dateEnrolled +
+                    "&dateCompleted=" + $stateParams.dateCompleted;
+                return "/" + $stateParams.configName + urlHelper.getPatientUrl() + "/" + defaultBoard.url + programParams;
             } else if (defaultBoard) {
-                return "/" + stateParams.configName + urlHelper.getPatientUrl() + "/" + defaultBoard.url + "?encounterUuid=active";
+                return "/" + $stateParams.configName + urlHelper.getPatientUrl() + "/" + defaultBoard.url + "?encounterUuid=active";
             }
             return urlHelper.getConsultationUrl();
         };

--- a/ui/app/clinical/common/services/treatmentService.js
+++ b/ui/app/clinical/common/services/treatmentService.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.clinical')
-    .factory('TreatmentService', ['$http', '$q', 'appService', function ($http, $q, appService) {
+    .factory('treatmentService', ['$http', '$q', 'appService', function ($http, $q, appService) {
         var createDrugOrder = function (drugOrder) {
             return Bahmni.Clinical.DrugOrder.create(drugOrder);
         };

--- a/ui/app/clinical/consultation/controllers/drugOrderHistoryController.js
+++ b/ui/app/clinical/consultation/controllers/drugOrderHistoryController.js
@@ -2,7 +2,7 @@
 
 angular.module('bahmni.clinical')
     .controller('DrugOrderHistoryController', ['$scope', '$filter', '$stateParams', 'activeDrugOrders',
-        'treatmentConfig', 'TreatmentService', 'spinner', 'drugOrderHistoryHelper', 'visitHistory', '$translate', '$rootScope',
+        'treatmentConfig', 'treatmentService', 'spinner', 'drugOrderHistoryHelper', 'visitHistory', '$translate', '$rootScope',
         function ($scope, $filter, $stateParams, activeDrugOrders, treatmentConfig, treatmentService, spinner,
                    drugOrderHistoryHelper, visitHistory, $translate, $rootScope) {
             var DrugOrderViewModel = Bahmni.Clinical.DrugOrderViewModel;

--- a/ui/app/clinical/consultation/directives/diagnosisAutoComplete.js
+++ b/ui/app/clinical/consultation/directives/diagnosisAutoComplete.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.clinical')
-    .directive('diagnosisAutoComplete', function ($parse) {
+    .directive('diagnosisAutoComplete', ['$parse', function ($parse) {
         var link = function (scope, element, attrs) {
             var ngModel = $parse(attrs.ngModel);
             var source = scope.source();
@@ -45,4 +45,4 @@ angular.module('bahmni.clinical')
                 index: '='
             }
         };
-    });
+    }]);

--- a/ui/app/clinical/consultation/directives/investigationsSelector.js
+++ b/ui/app/clinical/consultation/directives/investigationsSelector.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.clinical')
-.controller('InvestigationsSelectorController', function ($scope, spinner, configurations) {
+.controller('InvestigationsSelectorController', ['$scope', 'spinner', 'configurations', function ($scope, spinner, configurations) {
     var Selectable = Bahmni.Clinical.Selectable;
     var Category = Bahmni.Clinical.Category;
     $scope.selectablePanels = [];
@@ -144,7 +144,7 @@ angular.module('bahmni.clinical')
     $scope.selctedSelectables = function () {
         return $scope.allSelectables().filter(function (selectable) { return selectable.isSelectedFromSelf(); });
     };
-})
+}])
 .directive('investigationsSelector', function () {
     return {
         restrict: 'EA',

--- a/ui/app/clinical/consultation/services/treatmentConfig.js
+++ b/ui/app/clinical/consultation/services/treatmentConfig.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.clinical').factory('treatmentConfig',
-    ['TreatmentService', 'spinner', 'configurationService', 'appService', '$q', '$translate',
+    ['treatmentService', 'spinner', 'configurationService', 'appService', '$q', '$translate',
         function (treatmentService, spinner, configurationService, appService, $q, $translate) {
             var getConfigFromServer = function (baseTreatmentConfig) {
                 return treatmentService.getConfig().then(function (result) {

--- a/ui/app/clinical/displaycontrols/investigationresults/directives/investigationResults.js
+++ b/ui/app/clinical/displaycontrols/investigationresults/directives/investigationResults.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.clinical')
-    .directive('investigationResults', ['LabOrderResultService', 'spinner', function (labOrderResultService, spinner) {
+    .directive('investigationResults', ['labOrderResultService', 'spinner', function (labOrderResultService, spinner) {
         var controller = function ($scope) {
             var defaultParams = {
                 showTable: true,

--- a/ui/app/clinical/displaycontrols/investigationresults/offline/offlineLabOrderResultsService.js
+++ b/ui/app/clinical/displaycontrols/investigationresults/offline/offlineLabOrderResultsService.js
@@ -1,7 +1,8 @@
 'use strict';
 
 angular.module('bahmni.clinical')
-    .service('labOrderResultService', ['offlineLabOrderResultsService', '$q', 'configurationService', function (labOrderResultsService, $q, configurationService) {
+    .service('labOrderResultService', ['offlineLabOrderResultsService', '$q', 'configurationService', function (offlineLabOrderResultsService, $q, configurationService) {
+        var labOrderResultsService = offlineLabOrderResultsService;
         var allTestsAndPanelsConcept = {};
         configurationService.getConfigurations(['allTestsAndPanelsConcept']).then(function (configurations) {
             allTestsAndPanelsConcept = configurations.allTestsAndPanelsConcept.results[0];
@@ -84,7 +85,6 @@ angular.module('bahmni.clinical')
         };
         var getAllForPatient = function (params) {
             var deferred = $q.defer();
-            var paramsToBeSent = {};
             if (!params.patientUuid) {
                 deferred.reject('patient uuid is mandatory');
             }

--- a/ui/app/clinical/displaycontrols/investigationresults/offline/offlineLabOrderResultsService.js
+++ b/ui/app/clinical/displaycontrols/investigationresults/offline/offlineLabOrderResultsService.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.clinical')
-    .service('LabOrderResultService', ['offlineLabOrderResultsService', '$q', 'configurationService', function (labOrderResultsService, $q, configurationService) {
+    .service('labOrderResultService', ['offlineLabOrderResultsService', '$q', 'configurationService', function (labOrderResultsService, $q, configurationService) {
         var allTestsAndPanelsConcept = {};
         configurationService.getConfigurations(['allTestsAndPanelsConcept']).then(function (configurations) {
             allTestsAndPanelsConcept = configurations.allTestsAndPanelsConcept.results[0];

--- a/ui/app/clinical/displaycontrols/investigationresults/services/labOrderResultService.js
+++ b/ui/app/clinical/displaycontrols/investigationresults/services/labOrderResultService.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.clinical')
-    .factory('LabOrderResultService', ['$http', '$q', 'configurationService', function ($http, $q, configurationService) {
+    .factory('labOrderResultService', ['$http', '$q', 'configurationService', function ($http, $q, configurationService) {
         var allTestsAndPanelsConcept = {};
         configurationService.getConfigurations(['allTestsAndPanelsConcept']).then(function (configurations) {
             allTestsAndPanelsConcept = configurations.allTestsAndPanelsConcept.results[0];

--- a/ui/app/clinical/displaycontrols/treatmentData/directives/treatmentData.js
+++ b/ui/app/clinical/displaycontrols/treatmentData/directives/treatmentData.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.clinical')
-    .directive('treatmentData', ['TreatmentService', 'appService', 'spinner', '$stateParams', '$q', 'treatmentConfig', function (treatmentService, appService, spinner, $stateParams, $q, treatmentConfig) {
+    .directive('treatmentData', ['treatmentService', 'appService', 'spinner', '$stateParams', '$q', 'treatmentConfig', function (treatmentService, appService, spinner, $stateParams, $q, treatmentConfig) {
         var controller = function ($scope) {
             var Constants = Bahmni.Clinical.Constants;
             var defaultParams = {

--- a/ui/app/common/auth/authentication.js
+++ b/ui/app/common/auth/authentication.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('authentication')
-    .config(function ($httpProvider) {
+    .config(['$httpProvider', function ($httpProvider) {
         var interceptor = ['$rootScope', '$q', function ($rootScope, $q) {
             function success (response) {
                 return response;
@@ -20,7 +20,7 @@ angular.module('authentication')
             };
         }];
         $httpProvider.interceptors.push(interceptor);
-    }).run(['$rootScope', '$window', '$timeout', function ($rootScope, $window, $timeout) {
+    }]).run(['$rootScope', '$window', '$timeout', function ($rootScope, $window, $timeout) {
         $rootScope.$on('event:auth-loginRequired', function () {
             $timeout(function () {
                 $window.location = "../home/index.html#/login";

--- a/ui/app/common/auth/authentication.js
+++ b/ui/app/common/auth/authentication.js
@@ -261,7 +261,7 @@ angular.module('authentication')
             }
         };
     }])
-    .directive('btnUserInfo', ['$rootScope', '$window', function () {
+    .directive('btnUserInfo', [function () {
         return {
             restrict: 'CA',
             link: function (scope, elem) {

--- a/ui/app/common/concept-set/controller/multiSelectObservationSearchController.js
+++ b/ui/app/common/concept-set/controller/multiSelectObservationSearchController.js
@@ -75,8 +75,9 @@ angular.module('bahmni.common.conceptSet').controller('multiSelectObservationSea
     };
 
     init();
-}]).config(function (tagsInputConfigProvider) {
+}]).config(['tagsInputConfigProvider', function (tagsInputConfigProvider) {
     tagsInputConfigProvider.setDefaults('tagsInput', {
         placeholder: ''
-    }); });
+    });
+}]);
 

--- a/ui/app/common/config/directives/showIfPrivilege.js
+++ b/ui/app/common/config/directives/showIfPrivilege.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.common.config')
-    .directive('showIfPrivilege', function ($rootScope) {
+    .directive('showIfPrivilege', ['$rootScope', function ($rootScope) {
         return {
             scope: {
                 showIfPrivilege: "@"
@@ -19,5 +19,5 @@ angular.module('bahmni.common.config')
                 }
             }
         };
-    });
+    }]);
 

--- a/ui/app/common/displaycontrols/admissiondetails/directives/admissionDetails.js
+++ b/ui/app/common/displaycontrols/admissiondetails/directives/admissionDetails.js
@@ -1,7 +1,7 @@
 "use strict";
 
 angular.module('bahmni.common.displaycontrol.admissiondetails')
-    .directive('admissionDetails', ['bedService', 'visitService', function (bedService) {
+    .directive('admissionDetails', ['bedService', function (bedService) {
         var controller = function ($scope) {
             $scope.showDetailsButton = function (encounter) {
                 return $scope.params && $scope.params.showDetailsButton && !encounter.notes;

--- a/ui/app/common/displaycontrols/chronicTreatmentChart/directives/chronicTreatmentChart.js
+++ b/ui/app/common/displaycontrols/chronicTreatmentChart/directives/chronicTreatmentChart.js
@@ -1,13 +1,13 @@
 'use strict';
 
 angular.module('bahmni.common.displaycontrol.chronicTreatmentChart').directive('chronicTreatmentChart', ['$translate', 'spinner', 'drugService',
-    function ($translate, spinner, DrugService) {
+    function ($translate, spinner, drugService) {
         var link = function ($scope, element) {
             $scope.config = $scope.isOnDashboard ? $scope.section.dashboardConfig : $scope.section.expandedViewConfig;
             var patient = $scope.patient;
 
             var init = function () {
-                return DrugService.getRegimen(patient.uuid, $scope.enrollment, $scope.config.drugs).success(function (data) {
+                return drugService.getRegimen(patient.uuid, $scope.enrollment, $scope.config.drugs).success(function (data) {
                     var filterNullRow = function () {
                         for (var row in $scope.regimen.rows) {
                             var nullFlag = true;

--- a/ui/app/common/displaycontrols/drugOrderDetails/directives/drugOrderDetails.js
+++ b/ui/app/common/displaycontrols/drugOrderDetails/directives/drugOrderDetails.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.common.displaycontrol.drugOrderDetails')
-    .directive('drugOrderDetails', ['TreatmentService', 'spinner', 'treatmentConfig', '$q', function (treatmentService, spinner, treatmentConfig, $q) {
+    .directive('drugOrderDetails', ['treatmentService', 'spinner', 'treatmentConfig', '$q', function (treatmentService, spinner, treatmentConfig, $q) {
         var controller = function ($scope) {
             var init = function () {
                 return $q.all([treatmentService.getAllDrugOrdersFor($scope.patient.uuid, $scope.section.dashboardConfig.drugConceptSet, undefined, undefined, $scope.enrollment),

--- a/ui/app/common/displaycontrols/drugOrdersSection/directives/drugOrdersSection.js
+++ b/ui/app/common/displaycontrols/drugOrdersSection/directives/drugOrdersSection.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.common.displaycontrol.drugOrdersSection')
-    .directive('drugOrdersSection', ['TreatmentService', 'spinner', '$rootScope',
+    .directive('drugOrdersSection', ['treatmentService', 'spinner', '$rootScope',
         function (treatmentService, spinner, $rootScope) {
             var controller = function ($scope) {
                 var DateUtil = Bahmni.Common.Util.DateUtil;

--- a/ui/app/common/displaycontrols/forms/controllers/patientDashboardAllFormsController.js
+++ b/ui/app/common/displaycontrols/forms/controllers/patientDashboardAllFormsController.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.clinical')
-    .controller('patientDashboardAllFormsController', ['$scope', '$state', '$stateParams', 'ngDialog',
+    .controller('patientDashboardAllFormsController', ['$scope',
         function ($scope) {
             $scope.patient = $scope.ngDialogData.patient;
             $scope.section = $scope.ngDialogData.section;

--- a/ui/app/common/displaycontrols/hint/directives/hint.js
+++ b/ui/app/common/displaycontrols/hint/directives/hint.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.common.displaycontrol.hint')
-    .directive('hint', ['conceptSetService', 'spinner',
+    .directive('hint', [
         function () {
             var link = function ($scope) {
                 $scope.hintForNumericConcept = Bahmni.Common.Domain.Helper.getHintForNumericConcept($scope.conceptDetails);

--- a/ui/app/common/displaycontrols/prescription/directives/prescription.js
+++ b/ui/app/common/displaycontrols/prescription/directives/prescription.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.common.displaycontrol.prescription')
-    .directive('prescription', ['TreatmentService', 'treatmentConfig', '$q',
+    .directive('prescription', ['treatmentService', 'treatmentConfig', '$q',
         function (treatmentService, treatmentConfig, $q) {
             var controller = function ($scope) {
                 $q.all([treatmentConfig(), treatmentService.getPrescribedAndActiveDrugOrders($scope.patient.uuid, 1, false, [$scope.visitUuid], "", "", "")]).then(function (results) {

--- a/ui/app/common/domain/offline/offlineDiagnosisService.js
+++ b/ui/app/common/domain/offline/offlineDiagnosisService.js
@@ -2,7 +2,7 @@
 
 angular.module('bahmni.common.domain')
     .service('diagnosisService', ['$q', 'offlineEncounterServiceStrategy',
-        function ($q, offlineEncounterService) {
+        function ($q, offlineEncounterServiceStrategy) {
             var filterAndSortDiagnosis = function (diagnoses) {
                 diagnoses = _.filter(diagnoses, function (singleDiagnosis) {
                     return singleDiagnosis.revised == false;
@@ -14,7 +14,7 @@ angular.module('bahmni.common.domain')
             this.getDiagnoses = function (patientUuid, visitUuid) {
                 var deferred = $q.defer();
                 var diagnoses = [];
-                offlineEncounterService.getEncountersByPatientUuid(patientUuid).then(function (results) {
+                offlineEncounterServiceStrategy.getEncountersByPatientUuid(patientUuid).then(function (results) {
                     _.each(results, function (result) {
                         diagnoses = diagnoses.concat(result.encounter.bahmniDiagnoses);
                     });

--- a/ui/app/common/domain/offline/offlineEncounterService.js
+++ b/ui/app/common/domain/offline/offlineEncounterService.js
@@ -2,7 +2,8 @@
 
 angular.module('bahmni.common.domain')
     .service('encounterService', ['$q', '$rootScope', '$bahmniCookieStore', 'offlineEncounterServiceStrategy', 'eventQueue',
-        function ($q, $rootScope, $bahmniCookieStore, offlineEncounterService, eventQueue) {
+        function ($q, $rootScope, $bahmniCookieStore, offlineEncounterServiceStrategy, eventQueue) {
+            var offlineEncounterService = offlineEncounterServiceStrategy;
             this.buildEncounter = function (encounter) {
                 encounter.observations = encounter.observations || [];
                 encounter.providers = encounter.providers || [];

--- a/ui/app/common/i18n/bahmni-translate.js
+++ b/ui/app/common/i18n/bahmni-translate.js
@@ -1,7 +1,19 @@
 'use strict';
 
 angular.module('bahmni.common.i18n', ['pascalprecht.translate'])
-    .provider('$bahmniTranslate', $bahmniTranslateProvider)
+    .provider('$bahmniTranslate', ['$translateProvider', function ($translateProvider) {
+        this.init = function (options) {
+            var preferredLanguage = window.localStorage["NG_TRANSLATE_LANG_KEY"] || "en";
+            $translateProvider.useLoader('mergeLocaleFilesService', options);
+            $translateProvider.useSanitizeValueStrategy('escaped');
+            $translateProvider.preferredLanguage(preferredLanguage);
+            $translateProvider.useLocalStorage();
+        };
+        this.$get = [function () {
+            return $translateProvider;
+        }];
+    }
+    ])
     .filter('titleTranslate', ['$translate', function ($translate) {
         return function (input) {
             if (!input) {
@@ -25,18 +37,3 @@ angular.module('bahmni.common.i18n', ['pascalprecht.translate'])
             return $translate.instant(input);
         };
     }]);
-
-function $bahmniTranslateProvider ($translateProvider) {
-    this.init = function (options) {
-        var preferredLanguage = window.localStorage["NG_TRANSLATE_LANG_KEY"] || "en";
-        $translateProvider.useLoader('mergeLocaleFilesService', options);
-        $translateProvider.useSanitizeValueStrategy('escaped');
-        $translateProvider.preferredLanguage(preferredLanguage);
-        $translateProvider.useLocalStorage();
-    };
-    this.$get = [function () {
-        return $translateProvider;
-    }];
-}
-
-$bahmniTranslateProvider.$inject = ['$translateProvider'];

--- a/ui/app/common/logging/exceptionHandler.js
+++ b/ui/app/common/logging/exceptionHandler.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.common.logging')
-.config(function ($provide) {
+.config(['$provide', function ($provide) {
     $provide.decorator("$exceptionHandler", function ($delegate, $injector, $window, $log) {
         var logError = function (exception, cause) {
             try {
@@ -36,4 +36,4 @@ angular.module('bahmni.common.logging')
             logError(exception, cause);
         };
     });
-});
+}]);

--- a/ui/app/common/orders/offline/offlineOrderService.js
+++ b/ui/app/common/orders/offline/offlineOrderService.js
@@ -2,7 +2,8 @@
 
 angular.module('bahmni.common.domain')
     .factory('orderService', ['$q', 'offlineEncounterServiceStrategy',
-        function ($q, offlineEncounterService) {
+        function ($q, offlineEncounterServiceStrategy) {
+            var offlineEncounterService = offlineEncounterServiceStrategy;
             var getOrders = function (data) {
                 var orders = [];
                 var deferred = $q.defer();

--- a/ui/app/common/patient-search/directives/resize.js
+++ b/ui/app/common/patient-search/directives/resize.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.common.patientSearch')
-.directive('resize', function ($window) {
+.directive('resize', ['$window', function ($window) {
     var controller = function ($scope) {
         $scope.storeWindowDimensions = function () {
             var windowWidth = window.innerWidth;
@@ -52,4 +52,4 @@ angular.module('bahmni.common.patientSearch')
         template: '<div ng-transclude infinite-scroll="loadMore()">' +
                   '</div>'
     };
-});
+}]);

--- a/ui/app/common/patient-search/directives/scheduler.js
+++ b/ui/app/common/patient-search/directives/scheduler.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.common.patientSearch')
-    .directive('scheduler', function ($interval) {
+    .directive('scheduler', ['$interval', function ($interval) {
         var link = function ($scope) {
             var promise;
 
@@ -44,4 +44,4 @@ angular.module('bahmni.common.patientSearch')
                 triggerFunction: "&"
             }
         };
-    });
+    }]);

--- a/ui/app/common/patient/filters/birthDateToAgeText.js
+++ b/ui/app/common/patient/filters/birthDateToAgeText.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.common.patient')
-    .filter('birthDateToAgeText', function ($filter, $translate) {
+    .filter('birthDateToAgeText', ['$filter', '$translate', function ($filter, $translate) {
         return function (birthDate) {
             var DateUtil = Bahmni.Common.Util.DateUtil;
             if (birthDate) {
@@ -21,4 +21,4 @@ angular.module('bahmni.common.patient')
                 return "";
             }
         };
-    });
+    }]);

--- a/ui/app/common/patient/filters/dateToAge.js
+++ b/ui/app/common/patient/filters/dateToAge.js
@@ -1,11 +1,11 @@
 'use strict';
 
 angular.module('bahmni.common.patient')
-.filter('dateToAge', function ($filter) {
+.filter('dateToAge', ['$filter', function ($filter) {
     return function (birthDate, referenceDate) {
         var DateUtil = Bahmni.Common.Util.DateUtil;
         referenceDate = referenceDate || DateUtil.now();
         var age = DateUtil.diffInYearsMonthsDays(birthDate, referenceDate);
         return $filter('age')(age);
     };
-});
+}]);

--- a/ui/app/common/patient/filters/gender.js
+++ b/ui/app/common/patient/filters/gender.js
@@ -1,11 +1,11 @@
 'use strict';
 
 angular.module('bahmni.common.patient')
-.filter('gender', function ($rootScope) {
+.filter('gender', ['$rootScope', function ($rootScope) {
     return function (genderChar) {
         if (genderChar == null) {
             return "Unknown";
         }
         return $rootScope.genderMap[angular.uppercase(genderChar)];
     };
-});
+}]);

--- a/ui/app/common/route-errorhandler/init.js
+++ b/ui/app/common/route-errorhandler/init.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('bahmni.common.routeErrorHandler', ['ui.router'])
-    .run(function ($rootScope) {
+    .run(['$rootScope', function ($rootScope) {
         $rootScope.$on('$stateChangeError', function (event) {
             event.preventDefault();
         });
-    });
+    }]);

--- a/ui/app/common/ui-helper/directives.js
+++ b/ui/app/common/ui-helper/directives.js
@@ -45,7 +45,7 @@ angular.module('bahmni.common.uiHelper')
             link: link
         };
     })
-    .directive('myAutocomplete', function ($parse) {
+    .directive('myAutocomplete', ['$parse', function ($parse) {
         var link = function (scope, element, attrs, ngModelCtrl) {
             var ngModel = $parse(attrs.ngModel);
             var source = scope.source();
@@ -88,7 +88,7 @@ angular.module('bahmni.common.uiHelper')
                 onSelect: '&'
             }
         };
-    })
+    }])
     .directive('bmForm', ['$timeout', function ($timeout) {
         var link = function (scope, elem, attrs) {
             $timeout(function () {

--- a/ui/app/common/ui-helper/directives/autoScroll.js
+++ b/ui/app/common/ui-helper/directives/autoScroll.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('bahmni.common.uiHelper').directive('autoScroll', function ($location, $anchorScroll, $timeout) {
+angular.module('bahmni.common.uiHelper').directive('autoScroll', ['$location', '$anchorScroll', '$timeout', function ($location, $anchorScroll, $timeout) {
     var heightOfNavigationBar = 55;
     return {
         scope: {
@@ -22,4 +22,4 @@ angular.module('bahmni.common.uiHelper').directive('autoScroll', function ($loca
             });
         }
     };
-});
+}]);

--- a/ui/app/common/ui-helper/directives/dateConverter.js
+++ b/ui/app/common/ui-helper/directives/dateConverter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('bahmni.common.uiHelper').directive('dateConverter', ['$filter', function () {
+angular.module('bahmni.common.uiHelper').directive('dateConverter', [function () {
     return {
         require: 'ngModel',
         link: function (scope, element, attrs, ngModelController) {

--- a/ui/app/common/ui-helper/directives/focusMe.js
+++ b/ui/app/common/ui-helper/directives/focusMe.js
@@ -1,9 +1,7 @@
 'use strict';
 
 angular.module('bahmni.common.uiHelper')
-    .directive('focusMe',
-
-    function ($timeout, $parse) {
+    .directive('focusMe', ['$timeout', '$parse', function ($timeout, $parse) {
         return {
             link: function (scope, element, attrs) {
                 var model = $parse(attrs.focusMe);
@@ -16,5 +14,4 @@ angular.module('bahmni.common.uiHelper')
                 });
             }
         };
-    }
-);
+    }]);

--- a/ui/app/common/ui-helper/directives/focusOn.js
+++ b/ui/app/common/ui-helper/directives/focusOn.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.common.uiHelper')
-.directive('focusOn', function ($timeout) {
+.directive('focusOn', ['$timeout', function ($timeout) {
     return function (scope, elem, attrs) {
         if (Modernizr.ios) {
             return;
@@ -14,4 +14,4 @@ angular.module('bahmni.common.uiHelper')
             }
         });
     };
-});
+}]);

--- a/ui/app/common/ui-helper/directives/focusOnInputErrors.js
+++ b/ui/app/common/ui-helper/directives/focusOnInputErrors.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.common.uiHelper')
-    .directive('focusOnInputErrors', function ($timeout) {
+    .directive('focusOnInputErrors', ['$timeout', function ($timeout) {
         return function (scope) {
             var cleanUpListenerErrorsOnForm = scope.$on("event:errorsOnForm", function () {
                 $timeout(function () {
@@ -12,4 +12,4 @@ angular.module('bahmni.common.uiHelper')
 
             scope.$on("$destroy", cleanUpListenerErrorsOnForm);
         };
-    });
+    }]);

--- a/ui/app/common/ui-helper/directives/monthyearpicker.js
+++ b/ui/app/common/ui-helper/directives/monthyearpicker.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.common.uiHelper')
-    .directive('monthyearpicker', function ($translate) {
+    .directive('monthyearpicker', ['$translate', function ($translate) {
         var link = function ($scope) {
             var monthNames = $translate.instant('MONTHS');
             $scope.monthNames = monthNames.split(",");
@@ -72,4 +72,4 @@ angular.module('bahmni.common.uiHelper')
             '<span><select ng-model=\'selectedYear\'   ng-class=\"{\'illegalValue\': illegalYear() || illegalValue}\" ng-change="updateModel()" ng-options="year as year for year in years"><option value="">{{\'CHOOSE_YEAR_KEY\' | translate}}</option>>' +
             '</select></span>'
         };
-    });
+    }]);

--- a/ui/app/common/ui-helper/directives/splitButton.js
+++ b/ui/app/common/ui-helper/directives/splitButton.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.common.uiHelper')
-    .directive('splitButton', ['$timeout', '$parse', function ($timeout) {
+    .directive('splitButton', ['$timeout', function ($timeout) {
         var controller = function ($scope) {
             $scope.primaryOption = $scope.primaryOption || $scope.options[0];
             $scope.secondaryOptions = _.without($scope.options, $scope.primaryOption);

--- a/ui/app/common/ui-helper/services/backlinkService.js
+++ b/ui/app/common/ui-helper/services/backlinkService.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.common.uiHelper')
-    .service('backlinkService', function ($window) {
+    .service('backlinkService', ['$window', function ($window) {
         var self = this;
 
         var urls = [];
@@ -34,4 +34,4 @@ angular.module('bahmni.common.uiHelper')
         self.getAllUrls = function () {
             return urls;
         };
-    });
+    }]);

--- a/ui/app/common/util/httpErrorInterceptor.js
+++ b/ui/app/common/util/httpErrorInterceptor.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('httpErrorInterceptor', [])
-    .config(function ($httpProvider) {
+    .config(['$httpProvider', function ($httpProvider) {
         var interceptor = ['$rootScope', '$q', function ($rootScope, $q) {
             var serverErrorMessages = Bahmni.Common.Constants.serverErrorMessages;
 
@@ -72,4 +72,4 @@ angular.module('httpErrorInterceptor', [])
             };
         }];
         $httpProvider.interceptors.push(interceptor);
-    });
+    }]);

--- a/ui/app/home/app.js
+++ b/ui/app/home/app.js
@@ -68,9 +68,9 @@ angular.module('bahmni.home', ['ui.router', 'httpErrorInterceptor', 'bahmni.comm
             });
             $httpProvider.defaults.headers.common['Disable-WWW-Authenticate'] = true;
             $bahmniTranslateProvider.init({app: 'home', shouldMerge: true});
-        }]).run(function ($rootScope, $templateCache) {
+        }]).run(['$rootScope', '$templateCache', function ($rootScope, $templateCache) {
         // Disable caching view template partials
             $rootScope.$on('$viewContentLoaded', function () {
                 $templateCache.removeAll();
             });
-        });
+        }]);

--- a/ui/app/offline/app.js
+++ b/ui/app/offline/app.js
@@ -86,9 +86,9 @@ angular.module('bahmni.offline', ['ui.router', 'httpErrorInterceptor', 'bahmni.c
                     }
                 });
             $bahmniTranslateProvider.init({app: 'offline', shouldMerge: true});
-        }]).run(function ($rootScope, $templateCache) {
+        }]).run(['$rootScope', '$templateCache', function ($rootScope, $templateCache) {
     // Disable caching view template partials
             $rootScope.$on('$viewContentLoaded', function () {
                 $templateCache.removeAll();
             });
-        });
+        }]);

--- a/ui/app/registration/app.js
+++ b/ui/app/registration/app.js
@@ -94,7 +94,7 @@ angular
                 }
             });
         $bahmniTranslateProvider.init({app: 'registration', shouldMerge: true});
-    }]).run(function ($rootScope, $templateCache, offlineService, schedulerService, $bahmniCookieStore, locationService) {
+    }]).run(['$rootScope', '$templateCache', 'offlineService', 'schedulerService', '$bahmniCookieStore', 'locationService', function ($rootScope, $templateCache, offlineService, schedulerService, $bahmniCookieStore, locationService) {
         // Disable caching view template partials
 
         var loginLocationUuid = $bahmniCookieStore.get(Bahmni.Common.Constants.locationCookieName).uuid;
@@ -106,4 +106,4 @@ angular
         if (offlineService.isChromeApp() || offlineService.isAndroidApp()) {
             schedulerService.sync();
         }
-    });
+    }]);

--- a/ui/app/registration/controllers/createPatientController.js
+++ b/ui/app/registration/controllers/createPatientController.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('bahmni.registration')
-    .controller('CreatePatientController', ['$scope', '$rootScope', '$state', 'patientService', 'Preferences', 'patient', 'spinner', 'appService', 'messagingService', 'ngDialog', '$q', 'offlineService',
-        function ($scope, $rootScope, $state, patientService, preferences, patientModel, spinner, appService, messagingService, ngDialog, $q, offlineService) {
+    .controller('CreatePatientController', ['$scope', '$rootScope', '$state', 'patientService', 'patient', 'spinner', 'appService', 'messagingService', 'ngDialog', '$q', 'offlineService',
+        function ($scope, $rootScope, $state, patientService, patient, spinner, appService, messagingService, ngDialog, $q, offlineService) {
             var dateUtil = Bahmni.Common.Util.DateUtil;
             $scope.actions = {};
             var configValueForEnterId = appService.getAppDescriptor().getConfigValue('showEnterID');
@@ -65,7 +65,7 @@ angular.module('bahmni.registration')
             };
 
             var init = function () {
-                $scope.patient = patientModel.create();
+                $scope.patient = patient.create();
                 prepopulateDefaultsInFields();
                 expandSectionsWithDefaultValue();
                 $scope.patientLoaded = true;

--- a/ui/app/registration/controllers/editPatientController.js
+++ b/ui/app/registration/controllers/editPatientController.js
@@ -2,7 +2,7 @@
 
 angular.module('bahmni.registration')
     .controller('EditPatientController', ['$scope', 'patientService', 'encounterService', '$stateParams', 'openmrsPatientMapper', '$window', '$q', 'spinner', 'appService', 'messagingService', '$rootScope',
-        function ($scope, patientService, encounterService, $stateParams, patientMapper, $window, $q, spinner, appService, messagingService, $rootScope) {
+        function ($scope, patientService, encounterService, $stateParams, openmrsPatientMapper, $window, $q, spinner, appService, messagingService, $rootScope) {
             var dateUtil = Bahmni.Common.Util.DateUtil;
             var uuid = $stateParams.patientUuid;
             $scope.patient = {};
@@ -24,7 +24,7 @@ angular.module('bahmni.registration')
 
             var successCallBack = function (openmrsPatient) {
                 $scope.openMRSPatient = openmrsPatient["patient"];
-                $scope.patient = patientMapper.map(openmrsPatient);
+                $scope.patient = openmrsPatientMapper.map(openmrsPatient);
                 setReadOnlyFields();
                 expandDataFilledSections();
                 $scope.patientLoaded = true;

--- a/ui/app/registration/controllers/visitController.js
+++ b/ui/app/registration/controllers/visitController.js
@@ -2,7 +2,7 @@
 
 angular.module('bahmni.registration')
     .controller('VisitController', ['$window', '$scope', '$rootScope', '$state', '$bahmniCookieStore', 'patientService', 'encounterService', '$stateParams', 'spinner', '$timeout', '$q', 'appService', 'openmrsPatientMapper', 'contextChangeHandler', 'messagingService', 'sessionService', 'visitService', '$location', '$translate',
-        function ($window, $scope, $rootScope, $state, $bahmniCookieStore, patientService, encounterService, $stateParams, spinner, $timeout, $q, appService, patientMapper, contextChangeHandler, messagingService, sessionService, visitService, $location, $translate) {
+        function ($window, $scope, $rootScope, $state, $bahmniCookieStore, patientService, encounterService, $stateParams, spinner, $timeout, $q, appService, openmrsPatientMapper, contextChangeHandler, messagingService, sessionService, visitService, $location, $translate) {
             var vm = this;
             var patientUuid = $stateParams.patientUuid;
             var extensions = appService.getAppDescriptor().getExtensions("org.bahmni.registration.conceptSetGroup.observations", "config");
@@ -19,7 +19,7 @@ angular.module('bahmni.registration')
 
             var getPatient = function () {
                 return patientService.get(patientUuid).then(function (openMRSPatient) {
-                    $scope.patient = patientMapper.map(openMRSPatient);
+                    $scope.patient = openmrsPatientMapper.map(openMRSPatient);
                     $scope.patient.name = openMRSPatient.patient.person.names[0].display;
                     $scope.patient.uuid = openMRSPatient.patient.uuid;
                 });

--- a/ui/app/registration/directives/addressFields.js
+++ b/ui/app/registration/directives/addressFields.js
@@ -14,7 +14,7 @@ angular.module('bahmni.registration')
             }
         };
     })
-    .controller('AddressFieldsDirectiveController', function ($scope, addressHierarchyService) {
+    .controller('AddressFieldsDirectiveController', ['$scope', 'addressHierarchyService', function ($scope, addressHierarchyService) {
         var addressLevelsCloneInDescendingOrder = $scope.addressLevels.slice(0).reverse();
         $scope.addressLevelsChunks = Bahmni.Common.Util.ArrayUtil.chunk(addressLevelsCloneInDescendingOrder, 2);
         var addressLevelsNamesInDescendingOrder = addressLevelsCloneInDescendingOrder.map(function (addressLevel) {
@@ -81,4 +81,4 @@ angular.module('bahmni.registration')
             });
         };
         init();
-    });
+    }]);

--- a/ui/app/registration/directives/topDownAddressFields.js
+++ b/ui/app/registration/directives/topDownAddressFields.js
@@ -14,7 +14,7 @@ angular.module('bahmni.registration')
             }
         };
     })
-    .controller('TopDownAddressFieldsDirectiveController', function ($scope, addressHierarchyService) {
+    .controller('TopDownAddressFieldsDirectiveController', ['$scope', 'addressHierarchyService', function ($scope, addressHierarchyService) {
         $scope.addressFieldInvalid = false;
         var selectedAddressUuids = {};
         var selectedUserGeneratedIds = {};
@@ -156,4 +156,4 @@ angular.module('bahmni.registration')
             });
         };
         init();
-    });
+    }]);

--- a/ui/app/registration/initialization.js
+++ b/ui/app/registration/initialization.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.registration').factory('initialization',
-    ['$rootScope', '$q', 'configurations', 'authenticator', 'appService', 'spinner', 'Preferences', 'locationService', 'offlineService', 'offlineDbService', 'androidDbService', 'mergeService',
+    ['$rootScope', '$q', 'configurations', 'authenticator', 'appService', 'spinner', 'preferences', 'locationService', 'offlineService', 'offlineDbService', 'androidDbService', 'mergeService',
         function ($rootScope, $q, configurations, authenticator, appService, spinner, preferences, locationService, offlineService, offlineDbService, androidDbService, mergeService) {
             var getConfigs = function () {
                 var configNames = ['encounterConfig', 'patientAttributesConfig', 'identifierTypesConfig', 'addressLevels', 'genderMap', 'relationshipTypeConfig', 'relationshipTypeMap', 'loginLocationToVisitTypeMapping'];

--- a/ui/app/registration/mappers/openmrsPatientMapper.js
+++ b/ui/app/registration/mappers/openmrsPatientMapper.js
@@ -1,7 +1,8 @@
 'use strict';
 
 angular.module('bahmni.registration').factory('openmrsPatientMapper', ['patient', '$rootScope', 'age', 'identifiers',
-    function (patientModel, $rootScope, age, identifiers) {
+    function (patient, $rootScope, age, identifiers) {
+        var patientModel = patient;
         var whereAttributeTypeExists = function (attribute) {
                 return $rootScope.patientConfiguration.get(attribute.attributeType.uuid);
             },

--- a/ui/app/registration/models/identifiers.js
+++ b/ui/app/registration/models/identifiers.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.registration')
-    .factory('identifiers', ['$rootScope', 'Preferences', function ($rootScope, preferences) {
+    .factory('identifiers', ['$rootScope', 'preferences', function ($rootScope, preferences) {
         var create = function () {
             var identifiers = [];
             _.each($rootScope.patientConfiguration.identifierTypes, function (identifierType) {

--- a/ui/app/registration/models/preferences.js
+++ b/ui/app/registration/models/preferences.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.registration')
-    .factory('Preferences', ['$http', '$rootScope', function () {
+    .factory('Preferences', [function () {
         return {
             hasOldIdentifier: false
         };

--- a/ui/app/registration/models/preferences.js
+++ b/ui/app/registration/models/preferences.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('bahmni.registration')
-    .factory('Preferences', [function () {
+    .factory('preferences', [function () {
         return {
             hasOldIdentifier: false
         };

--- a/ui/app/reports/app.js
+++ b/ui/app/reports/app.js
@@ -62,9 +62,9 @@ angular
             };
 
             $bahmniTranslateProvider.init({app: getAppName(), shouldMerge: true});
-        }]).run(function ($rootScope, $templateCache) {
+        }]).run(['$rootScope', '$templateCache', function ($rootScope, $templateCache) {
             $rootScope.$on('$viewContentLoaded', function () {
                 $templateCache.removeAll();
             }
         );
-        });
+        }]);

--- a/ui/test/unit/adt/controllers/bedManagementController.spec.js
+++ b/ui/test/unit/adt/controllers/bedManagementController.spec.js
@@ -21,7 +21,7 @@ describe("BedManagementController", function () {
             $scope: scope,
             $rootScope: rootScope,
             $stateParams: {encounterUuid: "encounter uuid"},
-            WardService: wardService,
+            wardService: wardService,
             backlinkService: backlinkService
         });
     }

--- a/ui/test/unit/adt/controllers/wardLayoutController.spec.js
+++ b/ui/test/unit/adt/controllers/wardLayoutController.spec.js
@@ -3,7 +3,7 @@
 describe('WardLayoutController', function () {
 
     var bedService = jasmine.createSpyObj('bedService', ['assignBed', 'setBedDetailsForPatientOnRootScope']);
-    var wardService = jasmine.createSpyObj('WardService', ['bedsForWard']);
+    var wardService = jasmine.createSpyObj('wardService', ['bedsForWard']);
     var appService = jasmine.createSpyObj('appService', ['getAppDescriptor']);
     var messagingService = jasmine.createSpyObj('messagingService', ['showMessage']);
     var controller;
@@ -37,7 +37,7 @@ describe('WardLayoutController', function () {
     function createController() {
         return controller('WardLayoutController', {
             $scope: scope,
-            WardService: wardService,
+            wardService: wardService,
             bedManagementService: {},
             bedService: bedService,
             messagingService: messagingService,

--- a/ui/test/unit/adt/controllers/wardListController.spec.js
+++ b/ui/test/unit/adt/controllers/wardListController.spec.js
@@ -37,7 +37,7 @@ describe('WardListController', function () {
 
         controller('WardListController', {
             $scope: scope,
-            QueryService: queryService,
+            queryService: queryService,
             appService: appService
         });
 

--- a/ui/test/unit/adt/controllers/wardsController.spec.js
+++ b/ui/test/unit/adt/controllers/wardsController.spec.js
@@ -42,7 +42,7 @@ describe("WardsController", function () {
     });
 
     beforeEach(function () {
-        inject(function ($controller, $rootScope, _WardService_, bedService, userService) {
+        inject(function ($controller, $rootScope, _wardService_, bedService, userService) {
             scope = $rootScope.$new();
             rootScope = {
                 currentUser: {
@@ -51,7 +51,7 @@ describe("WardsController", function () {
                     }
                 }
             };
-            wardService = _WardService_;
+            wardService = _wardService_;
             bedService = bedService;
             userService = userService;
             createController = function () {

--- a/ui/test/unit/adt/services/QueryService.spec.js
+++ b/ui/test/unit/adt/services/QueryService.spec.js
@@ -13,8 +13,8 @@ describe('Query Service', function () {
             $provide.value('$http', mockHttp);
         });
 
-        inject(['QueryService', function (QueryServiceInjected) {
-            queryService = QueryServiceInjected;
+        inject(['queryService', function (queryServiceInjected) {
+            queryService = queryServiceInjected;
         }]);
     });
 

--- a/ui/test/unit/adt/services/bedManagementService.spec.js
+++ b/ui/test/unit/adt/services/bedManagementService.spec.js
@@ -1,4 +1,4 @@
-describe("BedManagementService", function() {
+describe("bedManagementService", function() {
     var bedLayouts = [
             {bedId: 1,
              bedNumber: "I1",
@@ -23,13 +23,13 @@ describe("BedManagementService", function() {
 
     beforeEach(module('bahmni.adt'));
 
-    beforeEach(inject(['BedManagementService', function (bedManagementServiceInjected) {
-    	BedManagementService = bedManagementServiceInjected
+    beforeEach(inject(['bedManagementService', function (bedManagementServiceInjected) {
+	bedManagementService = bedManagementServiceInjected
     }]));
 
 	describe("createLayoutGrid", function(){
 		it("should create grid layout", function(){
-            expect(BedManagementService.createLayoutGrid(bedLayouts).length).toBe(2);
+            expect(bedManagementService.createLayoutGrid(bedLayouts).length).toBe(2);
         });
     });
 });

--- a/ui/test/unit/adt/services/wardService.spec.js
+++ b/ui/test/unit/adt/services/wardService.spec.js
@@ -13,8 +13,8 @@ describe('Ward Service', function () {
             $provide.value('$http', mockHttp);
         });
 
-        inject(['WardService', function (WardServiceInjected) {
-            wardService = WardServiceInjected;
+        inject(['wardService', function (wardServiceInjected) {
+            wardService = wardServiceInjected;
         }]);
     });
 

--- a/ui/test/unit/clinical/common/services/treatmentService.spec.js
+++ b/ui/test/unit/clinical/common/services/treatmentService.spec.js
@@ -21,8 +21,8 @@ describe("TreamentService", function () {
     }));
 
 
-    beforeEach(inject(['TreatmentService', function (TreatmentService) {
-        this.treatmentService = TreatmentService;
+    beforeEach(inject(['treatmentService', function (treatmentService) {
+        this.treatmentService = treatmentService;
     }]));
 
     describe("treatment Service", function () {

--- a/ui/test/unit/clinical/consultation/services/treatmentConfig.spec.js
+++ b/ui/test/unit/clinical/consultation/services/treatmentConfig.spec.js
@@ -71,7 +71,7 @@ describe('treatmentConfig', function () {
             }));
             translate = jasmine.createSpyObj('$translate', ['instant']);
 
-            $provide.value('TreatmentService', treatmentService);
+            $provide.value('treatmentService', treatmentService);
             $provide.value('configurationService', configurationService);
             $provide.value('appService', appService);
             $provide.value('spinner', spinner);

--- a/ui/test/unit/clinical/controllers/addTreatmentController.spec.js
+++ b/ui/test/unit/clinical/controllers/addTreatmentController.spec.js
@@ -219,7 +219,7 @@ describe("AddTreatmentController", function () {
                 ngDialog: ngDialog,
                 appService: appService,
                 locationService :locationService,
-                DrugService: drugService,
+                drugService: drugService,
                 treatmentConfig: treatmentConfig,
                 orderSetService: orderSetService
             });

--- a/ui/test/unit/clinical/controllers/drugOrderHistoryController.spec.js
+++ b/ui/test/unit/clinical/controllers/drugOrderHistoryController.spec.js
@@ -24,7 +24,7 @@ describe("DrugOrderHistoryController", function () {
     beforeEach(inject(function (_$controller_, $rootScope, _$q_) {
         $q = _$q_;
         $controller = _$controller_;
-        _treatmentService = jasmine.createSpyObj('TreatmentService', ['getPrescribedDrugOrders']);
+        _treatmentService = jasmine.createSpyObj('treatmentService', ['getPrescribedDrugOrders']);
         _treatmentService.getPrescribedDrugOrders.and.callFake(function () {
             return specUtil.respondWithPromise($q, prescribedDrugOrders);
         });
@@ -51,7 +51,7 @@ describe("DrugOrderHistoryController", function () {
             $scope: scope,
             $translate: translate,
             activeDrugOrders: [activeDrugOrder, scheduledOrder],
-            TreatmentService: _treatmentService,
+            treatmentService: _treatmentService,
             retrospectiveEntryService: retrospectiveEntryService,
             $stateParams: {patientUuid: "patientUuid"},
             visitContext: {},

--- a/ui/test/unit/clinical/offline/offlineLabOrderResultService.spec.js
+++ b/ui/test/unit/clinical/offline/offlineLabOrderResultService.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 describe("offlineLabOrderResultService", function() {
-    var configurationService, LabOrderResultService, offlineLabOrderResultsService;
+    var configurationService, labOrderResultService, offlineLabOrderResultsService;
 
     beforeEach(module('bahmni.common.offline'));
     beforeEach(module('bahmni.clinical'));
@@ -43,8 +43,8 @@ describe("offlineLabOrderResultService", function() {
         $provide.value('configurationService', configurationService);
     }));
 
-    beforeEach(inject(['LabOrderResultService', 'offlineLabOrderResultsService', function (LabOrderResultServiceInjected, offlineLabOrderResultsService) {
-        LabOrderResultService = LabOrderResultServiceInjected;
+    beforeEach(inject(['labOrderResultService', 'offlineLabOrderResultsService', function (LabOrderResultServiceInjected, offlineLabOrderResultsService) {
+        labOrderResultService = LabOrderResultServiceInjected;
     }]));
 
     describe("getAllForPatient", function(){
@@ -55,7 +55,7 @@ describe("offlineLabOrderResultService", function() {
 
 
         it("should fetch all Lab orders & results and group by accessions", function(done){
-            LabOrderResultService.getAllForPatient(params).then(function(results) {
+            labOrderResultService.getAllForPatient(params).then(function(results) {
                 expect(offlineLabOrderResultsService.getLabOrderResultsForPatient).toHaveBeenCalled();
                 expect(results.labAccessions.length).toBe(2);
                 expect(results.labAccessions[0].length).toBe(1);
@@ -64,7 +64,7 @@ describe("offlineLabOrderResultService", function() {
             });
         });
         it("should sort by accession date and group by panel", function(done){
-            LabOrderResultService.getAllForPatient(params).then(function(results) {
+            labOrderResultService.getAllForPatient(params).then(function(results) {
                 expect(offlineLabOrderResultsService.getLabOrderResultsForPatient).toHaveBeenCalled();
                 expect(results.labAccessions[0][0].accessionUuid).toBe("uuid2");
                 expect(results.labAccessions[1][0].accessionUuid).toBe("uuid1");
@@ -73,7 +73,7 @@ describe("offlineLabOrderResultService", function() {
         });
 
         it("should group accessions by panel", function(done){
-            LabOrderResultService.getAllForPatient(params).then(function(results) {
+            labOrderResultService.getAllForPatient(params).then(function(results) {
                 expect(offlineLabOrderResultsService.getLabOrderResultsForPatient).toHaveBeenCalled();
                 expect(results.labAccessions[1][0].isPanel).toBeFalsy();
                 expect(results.labAccessions[1][0].orderName).toBe("ZN Stain(Sputum)");

--- a/ui/test/unit/clinical/services/labOrderResultService.spec.js
+++ b/ui/test/unit/clinical/services/labOrderResultService.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
-describe("LabOrderResultService", function() {
-    var mockHttp, configurationService, LabOrderResultService;
+describe("labOrderResultService", function() {
+    var mockHttp, configurationService, labOrderResultService;
 
     beforeEach(module('bahmni.clinical'));
 
@@ -42,8 +42,8 @@ describe("LabOrderResultService", function() {
         $provide.value('configurationService', configurationService);
     }));
 
-    beforeEach(inject(['LabOrderResultService', function (LabOrderResultServiceInjected) {
-        LabOrderResultService = LabOrderResultServiceInjected;
+    beforeEach(inject(['labOrderResultService', function (LabOrderResultServiceInjected) {
+        labOrderResultService = LabOrderResultServiceInjected;
     }]));
 
     describe("getAllForPatient", function(){
@@ -53,7 +53,7 @@ describe("LabOrderResultService", function() {
         };
 
         it("should fetch all Lab orders & results and group by accessions", function(done){
-            LabOrderResultService.getAllForPatient(params).then(function(results) {
+            labOrderResultService.getAllForPatient(params).then(function(results) {
                 expect(mockHttp.get.calls.mostRecent().args[1].params.patientUuid).toBe("123");
                 expect(results.labAccessions.length).toBe(2);
                 expect(results.labAccessions[0].length).toBe(1);
@@ -62,7 +62,7 @@ describe("LabOrderResultService", function() {
             });
         });
         it("should sort by accession date and group by panel", function(done){
-            LabOrderResultService.getAllForPatient(params).then(function(results) {
+            labOrderResultService.getAllForPatient(params).then(function(results) {
                 expect(mockHttp.get.calls.mostRecent().args[1].params.patientUuid).toBe("123");
                 expect(results.labAccessions[0][0].accessionUuid).toBe("uuid2");
                 expect(results.labAccessions[1][0].accessionUuid).toBe("uuid1");
@@ -71,7 +71,7 @@ describe("LabOrderResultService", function() {
         });
 
         it("should group accessions by panel", function(done){
-            LabOrderResultService.getAllForPatient(params).then(function(results) {
+            labOrderResultService.getAllForPatient(params).then(function(results) {
                 expect(mockHttp.get.calls.mostRecent().args[1].params.patientUuid).toBe("123");
 
                 expect(results.labAccessions[1][0].isPanel).toBeFalsy();

--- a/ui/test/unit/common/displaycontrols/drugOrderDetails/directives/drugOrderDetails.spec.js
+++ b/ui/test/unit/common/displaycontrols/drugOrderDetails/directives/drugOrderDetails.spec.js
@@ -49,7 +49,7 @@ describe('Drug Order Details DisplayControl', function () {
     beforeEach(module('bahmni.common.displaycontrol.drugOrderDetails'));
     beforeEach(module(function ($provide) {
         treatmentService = jasmine.createSpyObj('treatmentService', ['getAllDrugOrdersFor']);
-        $provide.value('TreatmentService', treatmentService);
+        $provide.value('treatmentService', treatmentService);
         $provide.value('treatmentConfig', function () {
             return {};
         });

--- a/ui/test/unit/common/displaycontrols/drugOrdersSection/directives/drugOrdersSection.spec.js
+++ b/ui/test/unit/common/displaycontrols/drugOrdersSection/directives/drugOrdersSection.spec.js
@@ -106,7 +106,7 @@ describe('DrugOrdersSection DisplayControl', function () {
 
     beforeEach(module(function ($provide) {
         treatmentService = jasmine.createSpyObj('treatmentService', ['getAllDrugOrdersFor', 'voidDrugOrder']);
-        $provide.value('TreatmentService', treatmentService);
+        $provide.value('treatmentService', treatmentService);
 
     }));
 

--- a/ui/test/unit/registration/models/identifiers.spec.js
+++ b/ui/test/unit/registration/models/identifiers.spec.js
@@ -3,7 +3,7 @@ describe("Identifiers", function () {
     var identifiersFactory, preferencesMock, rootScope;
     beforeEach(module('bahmni.registration'));
     beforeEach(module('bahmni.common.models'));
-    beforeEach(inject(['identifiers', 'Preferences', '$rootScope', function (identifiers, preferences, $rootScope) {
+    beforeEach(inject(['identifiers', 'preferences', '$rootScope', function (identifiers, preferences, $rootScope) {
         identifiersFactory = identifiers;
         preferencesMock = preferences;
         rootScope = $rootScope;


### PR DESCRIPTION
Fixing violations of ESLint [angular/di](https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/di.md) rule and enabling the rule at `error`level.

The rule has three alternatives:

* Function syntax
* Array syntax
* `$inject` syntax

Array syntax was chosen as it's in use across most of Bahmni, and is the preferred annotation option according to the [Angular docs](https://docs.angularjs.org/guide/di#dependency-annotation).

Most of the commits are fixing mismatches between parameter names and the elements in the array.

Some services were renamed to align with the [Factory and Service Names advice](https://github.com/johnpapa/angular-styleguide/blob/master/a1/README.md#style-y125) in  johnpapa's style guide.

The commit with message 'Convert all function syntax DI into array syntax' (b0dcac0 unless I rebase again) used a script to refactor all exiting annotations using function syntax to array syntax.

This is part of #37.