### PR TITLE
obsToObsFlowsheet: allow specification of a custom delimiter when multiple obs in a cell

### DIFF
--- a/ui/app/common/displaycontrols/tabularview/directives/obsToObsFlowSheet.js
+++ b/ui/app/common/displaycontrols/tabularview/directives/obsToObsFlowSheet.js
@@ -116,7 +116,7 @@ angular.module('bahmni.common.displaycontrol.obsVsObsFlowSheet').directive('obsT
                     list.push(name);
                 }
 
-                return list.join(', ');
+                return list.join($scope.config && $scope.config.obsDelimiter ? $scope.config.obsDelimiter : ', ');
             };
 
             $scope.isMonthAvailable = function () {

--- a/ui/app/common/displaycontrols/tabularview/views/obsToObsFlowSheet.html
+++ b/ui/app/common/displaycontrols/tabularview/views/obsToObsFlowSheet.html
@@ -38,7 +38,7 @@
                                      <img ng-src="{{ row.columns[header.name][0].value|thumbnail }}">
                                 </span>
                             </span>
-                            <span class="fl"
+                            <span class="fl wrap-on-line-break"
                                   ng-if="row.columns[header.name][0].concept.conceptClass != 'Image'"
                                   ng-class="{ 'obsTableData' : header.name === config.groupByConcept && isEditable }">{{::commafy(row.columns[header.name])}}</span>
                             <span class="fl" ng-if="header.name === config.groupByConcept && isEditable" >
@@ -65,7 +65,7 @@
                             <hint concept-details="header"/>
                         </td>
                         <td ng-repeat="row in obsTable.rows" ng-class="{'is-abnormal-bold': row.columns[header.name][0].abnormal , 'obsTableEdit' : header.name === config.groupByConcept && isEditable }">
-                        <span class="fl" ng-class="{ 'obsTableData' : header.name === config.groupByConcept && isEditable }">{{::commafy(row.columns[header.name])}}</span>
+                        <span class="fl wrap-on-line-break" ng-class="{ 'obsTableData' : header.name === config.groupByConcept && isEditable }">{{::commafy(row.columns[header.name])}}</span>
                         <span class="fl" ng-if="header.name === config.groupByConcept && isEditable" >
                                 <span class="has-link fl"
                                       ng-dialog="dashboard/views/dashboardSections/editObservationForm.html"

--- a/ui/app/styles/bahmni-helper/_base.scss
+++ b/ui/app/styles/bahmni-helper/_base.scss
@@ -336,3 +336,7 @@ table {
     display: block !important;
   }
 }
+
+.wrap-on-line-break {
+  white-space: pre-line;
+}

--- a/ui/test/unit/common/displaycontrols/obsVsObsFlowSheet/directives/obsToObsFlowSheet.spec.js
+++ b/ui/test/unit/common/displaycontrols/obsVsObsFlowSheet/directives/obsToObsFlowSheet.spec.js
@@ -429,6 +429,55 @@ describe('obsToObsFlowSheet DisplayControl', function () {
             expect(compiledElementScope.commafy(observations)).toEqual("7.2, 9.3");
         });
 
+        it('should return the values in by custom delimiter if specified and there are multiple values', function () {
+            var scope = rootScope.$new();
+
+            scope.isOnDashboard = true;
+            scope.section = {
+                "name": "obsToObsFlowSheet",
+                "headingConceptSource": "Abbreviation",
+                "dashboardConfig": {
+                    "conceptNames": [
+                        "Bacteriology, Rifampicin result",
+                        "Bacteriology, Ethambutol result"
+                    ],
+                    "obsDelimiter": ":"
+                }
+            };
+
+            scope.patient = {
+                "uuid": "patientUuid"
+            };
+
+            mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations/flowSheet?conceptNames=Bacteriology,+Rifampicin+result&conceptNames=Bacteriology,+Ethambutol+result&patientUuid=patientUuid').respond({});
+            mockBackend.expectGET('/openmrs/ws/rest/v1/concept?s=byFullySpecifiedName&v=custom:(uuid,names,displayString)').respond("<div>dummy</div>");
+
+            var element = compile(simpleHtml)(scope);
+
+            scope.$digest();
+            mockBackend.flush();
+
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            var observations = [
+                {
+                    concept: {
+                        dataType: 'Numeric'
+                    },
+                    value: 7.2
+                }, {
+                    concept: {
+                        dataType: 'Numeric'
+                    },
+                    value: 9.3
+                }
+            ];
+
+            expect(compiledElementScope.commafy(observations)).toEqual("7.2:9.3");
+        });
+
+
         it('should return just the value if there is only one value', function () {
             var scope = rootScope.$new();
 


### PR DESCRIPTION
To improve the layout of some Bahmni endTB tables, we'd like to change the delimiter used when there are multiple obs in cell from a comma to a newline.  I've added the ability specify a custom delimiter via a property "obsDelimiter" that can be part of the dashboardConfig, like so:

```
"dashboardConfig": {
          "groupByConcept": "Followup, Visit Date",
          "templateName": "Followup Template",
          "obsDelimiter": "\n",
          "conceptNames": [
            "Followup, Left Eye Correct Plates",
            "Followup, Right Eye Correct Plates"            
          ]
        }
```

Note that I also had to apply (via a new style I created) a "white-space: pre-line" to the sections in question to get the newline to be picked up.

Thoughts on this approach?

Card to track the progress for merge here -https://bahmni.mingle.thoughtworks.com/projects/bahmni_emr/cards/3386

fyi @deepaucksharma 
