### PR TITLE
sraza | mgoodrich | Add quantity and instruction fields to "drug order details" template

### DIFF
--- a/ui/app/common/displaycontrols/drugOrderDetails/directives/drugOrderDetails.js
+++ b/ui/app/common/displaycontrols/drugOrderDetails/directives/drugOrderDetails.js
@@ -23,9 +23,11 @@ angular.module('bahmni.common.displaycontrol.drugOrderDetails')
             $scope.columnHeaders = [
                 "DRUG_DETAILS_DRUG_NAME",
                 "DRUG_DETAILS_DOSE_INFO",
+                "DRUG_DETAILS_QUANTITY_TEXT",
                 "DRUG_DETAILS_ROUTE",
                 "DRUG_DETAILS_FREQUENCY",
                 "DRUG_DETAILS_START_DATE",
+                "DRUG_DETAILS_INSTRUCTIONS_TEXT",
                 "DRUG_DETAILS_ADDITIONAL_INSTRUCTIONS"
             ];
 

--- a/ui/app/common/displaycontrols/drugOrderDetails/views/drugOrderDetails.html
+++ b/ui/app/common/displaycontrols/drugOrderDetails/views/drugOrderDetails.html
@@ -21,6 +21,11 @@
                     <span>{{::drugOrder.getDoseAndUnits()}}</span>
                 </td>
                 <td>
+                    <span ng-show="drugOrder.quantity && drugOrder.quantity > 0">
+                        <span>{{::drugOrder.quantity}} </span><span>{{::drugOrder.quantityUnit}}</span>
+                    </span>
+                </td>
+                <td>
                     <span>{{::drugOrder.route}}</span>
                 </td>
                 <td>
@@ -29,11 +34,12 @@
                 <td class="days">
                     <span>{{::drugOrder.effectiveStartDate | bahmniDate}}</span>
                 </td>
-
+                <td>
+                    <span>{{::drugOrder.instructions || ""}}</span>
+                </td>
                 <td>
                     <span>{{::drugOrder.additionalInstructions || ""}}</span>
                 </td>
-
                 <td class="toggle-btn"
                     ng-if="::section.dashboardConfig.showDetailsButton">
                     <button class="toggle fr" toggle="drugOrder.showDetails">


### PR DESCRIPTION

There was a request from the endtb team to add the "quantity" and "instructions" column to the drug order details display.

I'm not sure if this is something we want across all of Bahmni, but I am issuing this pull request in order to start discussion.  If we don't want this globally, is there a way (or can we add a way) to configure what fields appear here.  Thanks!

@deepaucksharma 