### PR TITLE
Swathi |#3321 | Get revised latest obs for editing any obs in 'patient.dashboard.observation' angular state

### DIFF
--- a/ui/app/clinical/app.js
+++ b/ui/app/clinical/app.js
@@ -387,7 +387,7 @@ angular.module('consultation')
                 },
                 resolve: {
                     observation: function (observationsService, $stateParams) {
-                        return observationsService.getByUuid($stateParams.observationUuid).then(function (results) {
+                        return observationsService.getRevisedObsByUuid($stateParams.observationUuid).then(function (results) {
                             return results.data;
                         });
                     }

--- a/ui/app/common/domain/services/observationsService.js
+++ b/ui/app/common/domain/services/observationsService.js
@@ -33,6 +33,13 @@ angular.module('bahmni.common.domain')
             });
         };
 
+        this.getRevisedObsByUuid = function (observationUuid) {
+            return $http.get(Bahmni.Common.Constants.observationsUrl, {
+                params: {observationUuid: observationUuid, revision: "latest"},
+                withCredentials: true
+            });
+        };
+
         this.fetchForEncounter = function (encounterUuid, conceptNames) {
             return $http.get(Bahmni.Common.Constants.observationsUrl, {
                 params: {encounterUuid: encounterUuid, concept: conceptNames},


### PR DESCRIPTION
After OpenMRS 2.x upgrade the logic of Obs save changed. i.e when there is a change on obsTree at root level then entire tree will be replicated creating new Obs i.e the old obs uuid used to load the editobs page i.e 'patient.dashboard.observation' angular state is no more valid and the page throws exception.
To fix that we need to retrieve the revised obs when the obs is voided for replication.
This support for this is implemented in Bahmni-core and OpenMRS. Please refer to the below commits.
https://github.com/Bahmni/bahmni-core/commit/a7a25406019d21d069688e6919eb0f04e9de9c0f
https://github.com/openmrs/openmrs-core/commit/21225c255023f91c68b7466b1cdd6779fba7b598