### PR TITLE
rbuisson | Shrink table font size of Patient Search results

### DIFF
--- a/ui/app/styles/registration/_registrationSearch.scss
+++ b/ui/app/styles/registration/_registrationSearch.scss
@@ -83,6 +83,7 @@
   overflow-x: auto;
   table{
     margin-top: 20px;
+    font-size: 0.7rem;
     tr{
       border: none;
     }


### PR DESCRIPTION
	modified:   app/styles/registration/_registrationSearch.scss
Related to Talk thread: https://talk.openmrs.org/t/patient-search-results-table-font-seems-too-big/11887?u=mksrom