### PR TITLE
Introduced a toggle to hide conditions list.

### DIFF
--- a/ui/app/clinical/consultation/controllers/diagnosisController.js
+++ b/ui/app/clinical/consultation/controllers/diagnosisController.js
@@ -77,6 +77,7 @@ angular.module('bahmni.clinical')
                 $scope.canDeleteDiagnosis = findPrivilege(Bahmni.Common.Constants.deleteDiagnosisPrivilege);
                 $scope.allowOnlyCodedDiagnosis = appService.getAppDescriptor().getConfig("allowOnlyCodedDiagnosis") &&
                                                  appService.getAppDescriptor().getConfig("allowOnlyCodedDiagnosis").value;
+                $scope.hideConditions = appService.getAppDescriptor().getConfigValue("hideConditions");
                 addPlaceHolderDiagnosis();
                 diagnosisService.getDiagnosisConceptSet().then(function (result) {
                     $scope.diagnosisMetaData = result.data.results[0];

--- a/ui/app/clinical/consultation/views/diagnosis.html
+++ b/ui/app/clinical/consultation/views/diagnosis.html
@@ -105,7 +105,7 @@
                     </div>
                 </div>
 
-                <ng-include src="'consultation/views/conditions.html'"/>
+                <ng-include ng-if="!hideConditions" src="'consultation/views/conditions.html'"/>
             </div>
         </div>
     </fieldset>

--- a/ui/app/clinical/consultation/views/diagnosisRow.html
+++ b/ui/app/clinical/consultation/views/diagnosisRow.html
@@ -44,7 +44,7 @@
     <button id="deleteDiagnosis-{{$index}}" ng-confirm-click="deleteDiagnosis(diagnosis)" ng-if="canDeleteDiagnosis" class="small-btn row-remover remove-diagnosis" confirm-message="Are you sure you want to remove this diagnosis?"><span class="fa fa-remove"></span></button>
     <button id="addCondition-{{$index}}" ng-click="addDiagnosisToConditions(diagnosis)"
             ng-disabled="cannotBeACondition(diagnosis)"
-            ng-if="!isRetrospectiveMode()"
+            ng-if="!isRetrospectiveMode() && !hideConditions"
             class="small-btn add-condition">
         <span>Add as condition</span>
     </button>

--- a/ui/test/unit/clinical/consultation/controllers/diagnosisController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/diagnosisController.spec.js
@@ -17,8 +17,9 @@ describe("Diagnosis Controller", function () {
         rootScope.currentUser = {privileges: [{name: "app:clinical:deleteDiagnosis"}, {name: "app:clinical"}]};
 
         spyOn(DateUtil, 'today');
-        mockAppDescriptor = jasmine.createSpyObj('appDescriptor', ['getConfig']);
+        mockAppDescriptor = jasmine.createSpyObj('appDescriptor', ['getConfig','getConfigValue']);
         mockAppDescriptor.getConfig.and.returnValue({value: true});
+        mockAppDescriptor.getConfigValue.and.returnValue(true);
 
         appService = jasmine.createSpyObj('appService', ['getAppDescriptor']);
         appService.getAppDescriptor.and.returnValue(mockAppDescriptor);
@@ -75,6 +76,11 @@ describe("Diagnosis Controller", function () {
             $scope.$apply();
             expect($scope.isStatusConfigured).toBeTruthy();
             expect($scope.diagnosisMetaData).toBe(diagnosisMetaData.data.results[0]);
+        });
+
+        it("should set conditions to be hidden on UI when configured", function () {
+            expect(mockAppDescriptor.getConfigValue).toHaveBeenCalledWith("hideConditions");
+            expect($scope.hideConditions).toBeTruthy();
         });
     });
 


### PR DESCRIPTION
The condition-list won't be shown on diagnosis tab if `bahmni_config/openmrs/apps/clinical/app.json` file has a property `config.hideConditions`  set as `true`.
The condition-list will be shown if this property is not present or set to `false`.