### PR TITLE
Address Information sub-section heading

### DIFF
--- a/ui/app/registration/views/patientcommon.html
+++ b/ui/app/registration/views/patientcommon.html
@@ -133,7 +133,7 @@
                 <ng-include src="'views/age.html'"></ng-include>
             </div>
         </section>
-        <legend class="registraion_legend" ng-if="::!addressHierarchyConfigs.showAddressFieldsTopDown">
+        <legend class="registraion_legend">
             <span class="mylegend"> {{ ::'REGISTRATION_LABEL_ADDRESS_INFO' | translate}}</span>
         </legend>
 


### PR DESCRIPTION
Removed the ng-if condition on showAddressFieldsTopDown from address information sub-section heading. Details -  https://talk.openmrs.org/t/address-hierarchy-top-down-display/12138/2