### PR TITLE
BAH-311: Fill L10n gaps in registration app

### DIFF
--- a/ui/app/i18n/registration/locale_en.json
+++ b/ui/app/i18n/registration/locale_en.json
@@ -82,6 +82,7 @@
   "MESSAGE_DIALOG_OPTION_COPY" : "Copy Error",
   "MESSAGE_DIALOG_OPTION_OKAY": "OK",
   "NO_LOCATION_TAGGED_TO_VISIT_LOCATION": "No location tagged to Visit Location Found",
+  "REGISTRATION_ADDTIONAL_IDENTIFIERS": "Additional Identifiers",
   "REGISTRATION_FORM_ERRORS_MESSAGE_KEY": "Please enter a value in the mandatory fields or correct the value in the highlighted fields to proceed",
   "OBS_BOOLEAN_YES_KEY":"Yes",
   "OBS_BOOLEAN_NO_KEY":"No"

--- a/ui/app/registration/views/patientcommon.html
+++ b/ui/app/registration/views/patientcommon.html
@@ -1,4 +1,4 @@
-<div ng-controller="PatientCommonController">
+  <div ng-controller="PatientCommonController">
     <div class="box-container box-container-patient-info patient-common-info-container">
         <section>
             <article class="form-field patient-name-wrapper" ng-if="::patientConfiguration.local()['showNameField']">
@@ -147,7 +147,7 @@
                  strict-autocomplete-from-level="::addressHierarchyConfigs.strictAutocompleteFromLevel"></section>
 
         <legend class="registraion_legend" ng-if="patient.extraIdentifiers.length>0">
-            <span class="mylegend">Additional Identifiers</span>
+            <span class="mylegend">{{ ::'REGISTRATION_ADDTIONAL_IDENTIFIERS' | translate}}</span>
         </legend>
 
         <section>


### PR DESCRIPTION
Filling more L10n gaps, this time in the Registration app and a bit in the Home app.

**(Q)** This commit, such as the previous one (for the same JIRA task) is adding translation keys into the JSON files.
I am not sure if Transifex is just automatically updating its files from the ones on the repo or if it is supposed to be a manual process.
https://talk.openmrs.org/t/bahmni-changes-in-locale-en-json-should-i-update-transifex-as-well/14283

