### PR TITLE
Show Units irrespective of ranges configured

### DIFF
--- a/ui/app/clinical/displaycontrols/investigationresults/models/tabularLabOrderResults.js
+++ b/ui/app/clinical/displaycontrols/investigationresults/models/tabularLabOrderResults.js
@@ -50,6 +50,10 @@ Bahmni.Clinical.TabularLabOrderResults = (function () {
             return testOrderLabel.minNormal && testOrderLabel.maxNormal;
         };
 
+        this.hasUnits = function (testOrderLabel) {
+            return testOrderLabel.testUnitOfMeasurement != undefined && testOrderLabel.testUnitOfMeasurement != null;
+        };
+
         this.hasOrders = function () {
             return this.tabularResult.orders.length > 0;
         };

--- a/ui/app/clinical/displaycontrols/investigationresults/views/investigationChart.html
+++ b/ui/app/clinical/displaycontrols/investigationresults/views/investigationChart.html
@@ -13,10 +13,10 @@
                     <th>&nbsp;</th>
                     <td class="normal" ng-repeat="testOrderLabel in accessions.getTestOrderLabels()">
                         <span bo-text="testOrderLabel.testName"></span>
-                                <span ng-show="accessions.hasRange(testOrderLabel)" class="range">
-                                    <span bo-text="'(' + testOrderLabel.minNormal + ' - ' + testOrderLabel.maxNormal + ')'"></span>
-                                    <span bo-text="testOrderLabel.testUnitOfMeasurement"></span>
-                                </span>
+                            <span ng-show="accessions.hasRange(testOrderLabel)" class="range">
+                                <span bo-text="'(' + testOrderLabel.minNormal + ' - ' + testOrderLabel.maxNormal + ')'"></span>
+                            </span>
+                            <span bo-text="testOrderLabel.testUnitOfMeasurement" ng-show="accessions.hasUnits(testOrderLabel)" class="range" ></span>
                     </td>
                 </tr>
                 </thead>
@@ -68,8 +68,8 @@
                         <span bo-text="testOrderLabel.testName"></span>
                         <span ng-show="accessions.hasRange(testOrderLabel)" class="range">
                             <span bo-text="'(' + testOrderLabel.minNormal + ' - ' + testOrderLabel.maxNormal + ')'"></span>
-                            <span bo-text="testOrderLabel.testUnitOfMeasurement"></span>
                         </span>
+                        <span bo-text="testOrderLabel.testUnitOfMeasurement" ng-show="accessions.hasUnits(testOrderLabel)" class="range" ></span>
                     </th>
                     <td ng-repeat="dateLabel in accessions.getDateLabels()"
                         ng-class="{'has-uploaded-file': accessions.hasUploadedFiles(dateLabel, testOrderLabel)}">


### PR DESCRIPTION
In Investigation chart display control, Test units are displayed only when ranges are configured. 
Made changes to show units when configured irrespective of ranges.