### PR TITLE
Fix BAH-423: Date is not retained after patient search

### DIFF
--- a/ui/app/appointments/controllers/manage/list/appointmentsListViewController.js
+++ b/ui/app/appointments/controllers/manage/list/appointmentsListViewController.js
@@ -37,6 +37,7 @@ angular.module('bahmni.appointments')
             };
 
             $scope.getAppointmentsForDate = function (viewDate) {
+                $scope.startDate = viewDate;
                 $stateParams.viewDate = viewDate;
                 $scope.selectedAppointment = undefined;
                 var params = {forDate: viewDate};


### PR DESCRIPTION
--- In appointmentsSummaryController ---
Total count is clicked:
        - state changes to 'home.manage.appointments.list' is triggered, and the date is passed in $stateParams.viewDate

--- In appointmentsListViewController ---
Controller is initialized:
        - $scope.startDate is set to $stateParams.viewDate
        - datePicker.viewDate is initialized to $scope.startDate (1 way binding)
        - datePicker change triggers $scope.getAppointmentsForDate, appointments are populated

Date is changed using < or >:
        - datePicker.viewDate is updated from ngClick directive
        - datePicker change triggers $scope.getAppointmentsForDate, appointments are populated
        - $scope.getAppointmentsForDate UPDATES $stateParams.viewDate but LEAVES $scope.startDate UNTOUCHED !!!

User is clicked on from search results:
        - $scope.displaySearchedPatient shows search results, removes datePicker from DOM

Reset is clicked:
        - $scope.goBackToPreviousView hides search results, adds datePicker to DOM
        - datePicker.viewDate is initialized to $scope.startDate which retains old value, WAS NOT UPDATED ON < > click