### PR TITLE
BAH-497: Prompt to save if home or search clicked in registration screen

### DIFF
--- a/ui/app/i18n/registration/locale_en.json
+++ b/ui/app/i18n/registration/locale_en.json
@@ -1,4 +1,7 @@
 {
+  "SAVE_CONFIRMATION_DIALOG_MESSAGE_KEY": "You may have unsaved changes, please choose an option.",
+  "SAVE_CONFIRMATION_OPTION_DONT_SAVE_KEY" : "Don't Save",
+  "SAVE_CONFIRMATION_OPTION_CANCEL_KEY" : "Cancel",
   "REGISTRATION_TITLE_KEY": "Patient Registration",
   "REGISTRATION_LABEL_SCANNED" : "Scanned",
   "REGISTRATION_LABEL_PAPER" : "Paper",

--- a/ui/app/registration/controllers/patientCommonController.js
+++ b/ui/app/registration/controllers/patientCommonController.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('bahmni.registration')
-    .controller('PatientCommonController', ['$scope', '$rootScope', '$http', 'patientAttributeService', 'appService', 'spinner',
-        function ($scope, $rootScope, $http, patientAttributeService, appService, spinner) {
+    .controller('PatientCommonController', ['$scope', '$rootScope', '$http', 'patientAttributeService', 'appService', 'spinner', '$location', 'ngDialog', '$window', '$state',
+        function ($scope, $rootScope, $http, patientAttributeService, appService, spinner, $location, ngDialog, $window, $state) {
             var autoCompleteFields = appService.getAppDescriptor().getConfigValue("autoCompleteFields", []);
             var showCasteSameAsLastNameCheckbox = appService.getAppDescriptor().getConfigValue("showCasteSameAsLastNameCheckbox");
             var personAttributes = [];
@@ -15,6 +15,59 @@ angular.module('bahmni.registration')
             $scope.genderCodes = Object.keys($rootScope.genderMap);
             $scope.dobMandatory = appService.getAppDescriptor().getConfigValue("dobMandatory") || false;
             $scope.readOnlyExtraIdentifiers = appService.getAppDescriptor().getConfigValue("readOnlyExtraIdentifiers");
+            $scope.showSaveConfirmDialogConfig = appService.getAppDescriptor().getConfigValue("showSaveConfirmDialog");
+
+            // Flag variable to check if Dont Save button is pressed or not
+            var flag = 0;
+
+            // Flag to check whether the button has an href or not
+            var hrefFlag = 0;
+
+            // Function is called when the Home Button is Clicked
+            $rootScope.homeNavigate = function () {
+                if ($scope.showSaveConfirmDialogConfig) {
+                    event.preventDefault();
+                    $scope.targetUrl = event.currentTarget.getAttribute('href');
+                    naviConfirmBox(event);
+                }
+            };
+
+            // Checks for State Change
+            var stateChangeListener = $rootScope.$on("$stateChangeStart", function (event, toState, toParams, fromState, fromParams) {
+                naviConfirmBox(event, toState, toParams, fromState, fromParams);
+            });
+
+            var naviConfirmBox = function (event, toState) {
+                if (flag === 0) {
+                    if ($scope.showSaveConfirmDialogConfig) {
+                        if (event) {
+                            event.preventDefault();
+                            if ($scope.targetUrl) {
+                                hrefFlag = 1;
+                            } else {
+                                $scope.targetUrl = toState.name;
+                                hrefFlag = 0;
+                            }
+                        }
+                        ngDialog.openConfirm({template: "views/navigationPrompt.html", scope: $scope});
+                    }
+                }
+            };
+
+            $scope.continueWithoutSaving = function () {
+                ngDialog.close();
+                flag = 1;
+                if (hrefFlag === 1) {
+                    $window.open($scope.targetUrl, '_self');
+                } else {
+                    $state.go($scope.targetUrl);
+                }
+            };
+
+            $scope.saveAndContinue = function () {
+                ngDialog.close();
+                delete $scope.targetUrl;
+            };
 
             $scope.getDeathConcepts = function () {
                 return $http({

--- a/ui/app/registration/views/header.html
+++ b/ui/app/registration/views/header.html
@@ -1,6 +1,6 @@
 <header class="reg-header" ng-controller="NavigationController">
         <ul class="top-nav fl">
-            <a class="back-btn" accesskey="h" href="../home/index.html"><i class="fa fa-home"></i></a>
+            <a class="back-btn" accesskey="h" href="../home/index.html" ng-click="homeNavigate()"><i class="fa fa-home"></i></a>
             <li ng-repeat="extension in ::extensions">
                 <a ng-click="goTo(extension.url)" accesskey="{{::extension.shortcutKey | translate}}"><i class="{{::extension.icon}} fa fa-white small"></i>
                     <span class="nav-link" ng-bind-html="::extension | titleTranslate"></span></a>

--- a/ui/app/registration/views/navigationPrompt.html
+++ b/ui/app/registration/views/navigationPrompt.html
@@ -1,0 +1,21 @@
+<div class="revise-refill-modal-wrapper" aria-labelledby="dialog-label">
+    <!--Added to override the z-index property of the top navigation bar. It is done to prevent any user action
+    when the popup is shown-->
+    <style type="text/css">
+        .opd-header-wrapper {
+            z-index: 10000 !important;
+        }
+    </style>
+    <div class="drug-details">
+        <p>{{'SAVE_CONFIRMATION_DIALOG_MESSAGE_KEY' | translate}}</p>
+    </div>
+
+    <div class="dialog-button-group">
+        <button id="modal-revise-button1" class="secondary-button" ng-click="continueWithoutSaving()">{{'SAVE_CONFIRMATION_OPTION_DONT_SAVE_KEY' | translate}}</button>
+        <button id="modal-revise-button2" class="secondary-button" ng-click="saveAndContinue()">{{'SAVE_CONFIRMATION_OPTION_CANCEL_KEY' | translate}}</button>
+    </div>
+
+    <span class="ngdialog-end"></span>
+</div>
+
+

--- a/ui/test/unit/registration/controllers/patientCommonController.spec.js
+++ b/ui/test/unit/registration/controllers/patientCommonController.spec.js
@@ -5,7 +5,7 @@ describe('PatientCommonController', function () {
     var $aController, $httpBackend, scope, appService, rootScope, patientAttributeService;
     var spinner = jasmine.createSpyObj('spinner', ['forPromise']);
 
-    beforeEach(module('bahmni.registration'));
+    beforeEach(module('bahmni.registration', 'ngDialog'));
 
     beforeEach(module(function ($provide) {
         $provide.value('patientAttributeService', {});


### PR DESCRIPTION
1.A confirm box has been added when ever the user tries to navigate away from the patient registration screen.  
2.The above prompt is enabled through the following config being set to true in registration/app.js: "showSaveConfirmDialog" : true
3. However "stateChangeStart" and "locationChangeStart" are not getting triggered for the Home button and preventing to leverage the above functionality.
4. The desired outcome is achievable by setting an "id" attribute to the Home button and calling a function when the button is clicked.
5.Navigating away through

- Clicking on Search button
- URL  change
- Navigating away from patient registration page
- Clicking the Chrome's back button triggers the confirmation prompt to appear as it does in 'clinical'.