### PR TITLE
BAH-497: Prompt to save if home or search clicked in registration screen

### DIFF
--- a/ui/app/clinical/consultation/controllers/consultationController.js
+++ b/ui/app/clinical/consultation/controllers/consultationController.js
@@ -18,6 +18,7 @@ angular.module('bahmni.clinical').controller('ConsultationController',
                 return $state.current.name === 'patient.dashboard.show';
             };
             $scope.showComment = true;
+            $scope.isClinical = true;
 
             $scope.visitHistory = visitHistory;
             $scope.consultationBoardLink = clinicalAppConfigService.getConsultationBoardLink();
@@ -182,7 +183,7 @@ angular.module('bahmni.clinical').controller('ConsultationController',
                         event.preventDefault();
                         $scope.targetUrl = event.currentTarget.getAttribute('href');
                     }
-                    ngDialog.openConfirm({template: 'consultation/views/saveConfirmation.html', scope: $scope});
+                    ngDialog.openConfirm({template: '../common/ui-helper/views/saveConfirmation.html', scope: $scope});
                 }
             };
 

--- a/ui/app/clinical/consultation/controllers/consultationController.js
+++ b/ui/app/clinical/consultation/controllers/consultationController.js
@@ -18,7 +18,7 @@ angular.module('bahmni.clinical').controller('ConsultationController',
                 return $state.current.name === 'patient.dashboard.show';
             };
             $scope.showComment = true;
-            $scope.shouldShowSaveAndContinueButton = true;
+            $scope.showSaveAndContinueButton = true;
 
             $scope.visitHistory = visitHistory;
             $scope.consultationBoardLink = clinicalAppConfigService.getConsultationBoardLink();

--- a/ui/app/clinical/consultation/controllers/consultationController.js
+++ b/ui/app/clinical/consultation/controllers/consultationController.js
@@ -18,7 +18,7 @@ angular.module('bahmni.clinical').controller('ConsultationController',
                 return $state.current.name === 'patient.dashboard.show';
             };
             $scope.showComment = true;
-            $scope.isClinical = true;
+            $scope.shouldShowSaveAndContinueButton = true;
 
             $scope.visitHistory = visitHistory;
             $scope.consultationBoardLink = clinicalAppConfigService.getConsultationBoardLink();

--- a/ui/app/common/ui-helper/views/saveConfirmation.html
+++ b/ui/app/common/ui-helper/views/saveConfirmation.html
@@ -13,7 +13,7 @@
     <div class="dialog-button-group">
         <button id="modal-revise-button1" class="secondary-button" ng-click="continueWithoutSaving()">{{'SAVE_CONFIRMATION_OPTION_DONT_SAVE_KEY' | translate}}</button>
         <button id="modal-revise-button2" class="secondary-button" ng-click="cancelTransition()">{{'SAVE_CONFIRMATION_OPTION_CANCEL_KEY' | translate}}</button>
-        <button id="modal-revise-button3" class="secondary-button" ng-click="saveAndContinue()" ng-show="shouldShowSaveAndContinueButton">{{'SAVE_CONFIRMATION_OPTION_SAVE_KEY' | translate}}</button>
+        <button id="modal-revise-button3" class="secondary-button" ng-click="saveAndContinue()" ng-show="showSaveAndContinueButton">{{'SAVE_CONFIRMATION_OPTION_SAVE_KEY' | translate}}</button>
     </div>
 
     <span class="ngdialog-end"></span>

--- a/ui/app/common/ui-helper/views/saveConfirmation.html
+++ b/ui/app/common/ui-helper/views/saveConfirmation.html
@@ -13,7 +13,7 @@
     <div class="dialog-button-group">
         <button id="modal-revise-button1" class="secondary-button" ng-click="continueWithoutSaving()">{{'SAVE_CONFIRMATION_OPTION_DONT_SAVE_KEY' | translate}}</button>
         <button id="modal-revise-button2" class="secondary-button" ng-click="cancelTransition()">{{'SAVE_CONFIRMATION_OPTION_CANCEL_KEY' | translate}}</button>
-        <button id="modal-revise-button3" class="secondary-button" ng-click="saveAndContinue()" ng-show="isClinical">{{'SAVE_CONFIRMATION_OPTION_SAVE_KEY' | translate}}</button>
+        <button id="modal-revise-button3" class="secondary-button" ng-click="saveAndContinue()" ng-show="shouldShowSaveAndContinueButton">{{'SAVE_CONFIRMATION_OPTION_SAVE_KEY' | translate}}</button>
     </div>
 
     <span class="ngdialog-end"></span>

--- a/ui/app/common/ui-helper/views/saveConfirmation.html
+++ b/ui/app/common/ui-helper/views/saveConfirmation.html
@@ -13,7 +13,7 @@
     <div class="dialog-button-group">
         <button id="modal-revise-button1" class="secondary-button" ng-click="continueWithoutSaving()">{{'SAVE_CONFIRMATION_OPTION_DONT_SAVE_KEY' | translate}}</button>
         <button id="modal-revise-button2" class="secondary-button" ng-click="cancelTransition()">{{'SAVE_CONFIRMATION_OPTION_CANCEL_KEY' | translate}}</button>
-        <button id="modal-revise-button3" class="secondary-button" ng-click="saveAndContinue()">{{'SAVE_CONFIRMATION_OPTION_SAVE_KEY' | translate}}</button>
+        <button id="modal-revise-button3" class="secondary-button" ng-click="saveAndContinue()" ng-show="isClinical">{{'SAVE_CONFIRMATION_OPTION_SAVE_KEY' | translate}}</button>
     </div>
 
     <span class="ngdialog-end"></span>

--- a/ui/app/i18n/registration/locale_en.json
+++ b/ui/app/i18n/registration/locale_en.json
@@ -1,4 +1,7 @@
 {
+  "SAVE_CONFIRMATION_DIALOG_MESSAGE_KEY": "You may have unsaved changes, please choose an option.",
+  "SAVE_CONFIRMATION_OPTION_DONT_SAVE_KEY" : "Don't Save",
+  "SAVE_CONFIRMATION_OPTION_CANCEL_KEY" : "Cancel",
   "REGISTRATION_TITLE_KEY": "Patient Registration",
   "REGISTRATION_LABEL_SCANNED" : "Scanned",
   "REGISTRATION_LABEL_PAPER" : "Paper",

--- a/ui/app/registration/controllers/patientCommonController.js
+++ b/ui/app/registration/controllers/patientCommonController.js
@@ -16,9 +16,9 @@ angular.module('bahmni.registration')
             $scope.dobMandatory = appService.getAppDescriptor().getConfigValue("dobMandatory") || false;
             $scope.readOnlyExtraIdentifiers = appService.getAppDescriptor().getConfigValue("readOnlyExtraIdentifiers");
             $scope.showSaveConfirmDialogConfig = appService.getAppDescriptor().getConfigValue("showSaveConfirmDialog");
-            $scope.shouldShowSaveAndContinueButton = false;
+            $scope.showSaveAndContinueButton = false;
 
-            var savedButtonClicked = false;
+            var dontSaveButtonClicked = false;
 
             var isHref = false;
 
@@ -40,7 +40,7 @@ angular.module('bahmni.registration')
             });
 
             $scope.confirmationPrompt = function (event, toState) {
-                if (savedButtonClicked === false) {
+                if (dontSaveButtonClicked === false) {
                     if (event) {
                         event.preventDefault();
                     }
@@ -50,7 +50,7 @@ angular.module('bahmni.registration')
 
             $scope.continueWithoutSaving = function () {
                 ngDialog.close();
-                savedButtonClicked = true;
+                dontSaveButtonClicked = true;
                 if (isHref === true) {
                     $window.open($scope.targetUrl, '_self');
                 } else {

--- a/ui/app/registration/controllers/patientCommonController.js
+++ b/ui/app/registration/controllers/patientCommonController.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('bahmni.registration')
-    .controller('PatientCommonController', ['$scope', '$rootScope', '$http', 'patientAttributeService', 'appService', 'spinner',
-        function ($scope, $rootScope, $http, patientAttributeService, appService, spinner) {
+    .controller('PatientCommonController', ['$scope', '$rootScope', '$http', 'patientAttributeService', 'appService', 'spinner', '$location', 'ngDialog', '$window', '$state',
+        function ($scope, $rootScope, $http, patientAttributeService, appService, spinner, $location, ngDialog, $window, $state) {
             var autoCompleteFields = appService.getAppDescriptor().getConfigValue("autoCompleteFields", []);
             var showCasteSameAsLastNameCheckbox = appService.getAppDescriptor().getConfigValue("showCasteSameAsLastNameCheckbox");
             var personAttributes = [];
@@ -15,6 +15,60 @@ angular.module('bahmni.registration')
             $scope.genderCodes = Object.keys($rootScope.genderMap);
             $scope.dobMandatory = appService.getAppDescriptor().getConfigValue("dobMandatory") || false;
             $scope.readOnlyExtraIdentifiers = appService.getAppDescriptor().getConfigValue("readOnlyExtraIdentifiers");
+            $scope.showSaveConfirmDialogConfig = appService.getAppDescriptor().getConfigValue("showSaveConfirmDialog");
+            $scope.isClinical = false;
+
+            var savedButtonClicked = false;
+
+            var isHref = false;
+
+            $rootScope.homeNavigate = function () {
+                if ($scope.showSaveConfirmDialogConfig) {
+                    event.preventDefault();
+                    $scope.targetUrl = event.currentTarget.getAttribute('href');
+                    $scope.naviConfirmBox(event);
+                }
+            };
+
+            var stateChangeListener = $rootScope.$on("$stateChangeStart", function (event, toState, toParams) {
+                $scope.naviConfirmBox(event, toState, toParams);
+            });
+
+            $scope.naviConfirmBox = function (event, toState) {
+                if (savedButtonClicked === false) {
+                    if ($scope.showSaveConfirmDialogConfig) {
+                        if (event) {
+                            event.preventDefault();
+                            if ($scope.targetUrl) {
+                                isHref = true;
+                            } else {
+                                $scope.targetUrl = toState.name;
+                                isHref = false;
+                            }
+                        }
+                        ngDialog.openConfirm({template: "../common/ui-helper/views/saveConfirmation.html", scope: $scope});
+                    }
+                }
+            };
+
+            $scope.continueWithoutSaving = function () {
+                ngDialog.close();
+                savedButtonClicked = true;
+                if (isHref === true) {
+                    $window.open($scope.targetUrl, '_self');
+                } else {
+                    $state.go($scope.targetUrl);
+                }
+            };
+
+            $scope.cancelTransition = function () {
+                ngDialog.close();
+                delete $scope.targetUrl;
+            };
+
+            $scope.$on("$destroy", function () {
+                stateChangeListener();
+            });
 
             $scope.getDeathConcepts = function () {
                 return $http({

--- a/ui/app/registration/controllers/patientCommonController.js
+++ b/ui/app/registration/controllers/patientCommonController.js
@@ -16,38 +16,35 @@ angular.module('bahmni.registration')
             $scope.dobMandatory = appService.getAppDescriptor().getConfigValue("dobMandatory") || false;
             $scope.readOnlyExtraIdentifiers = appService.getAppDescriptor().getConfigValue("readOnlyExtraIdentifiers");
             $scope.showSaveConfirmDialogConfig = appService.getAppDescriptor().getConfigValue("showSaveConfirmDialog");
-            $scope.isClinical = false;
+            $scope.shouldShowSaveAndContinueButton = false;
 
             var savedButtonClicked = false;
 
             var isHref = false;
 
-            $rootScope.homeNavigate = function () {
+            $rootScope.onHomeNavigate = function () {
                 if ($scope.showSaveConfirmDialogConfig) {
                     event.preventDefault();
                     $scope.targetUrl = event.currentTarget.getAttribute('href');
-                    $scope.naviConfirmBox(event);
+                    isHref = true;
+                    $scope.confirmationPrompt(event);
                 }
             };
 
             var stateChangeListener = $rootScope.$on("$stateChangeStart", function (event, toState, toParams) {
-                $scope.naviConfirmBox(event, toState, toParams);
+                if ($scope.showSaveConfirmDialogConfig) {
+                    $scope.targetUrl = toState.name;
+                    isHref = false;
+                    $scope.confirmationPrompt(event, toState, toParams);
+                }
             });
 
-            $scope.naviConfirmBox = function (event, toState) {
+            $scope.confirmationPrompt = function (event, toState) {
                 if (savedButtonClicked === false) {
-                    if ($scope.showSaveConfirmDialogConfig) {
-                        if (event) {
-                            event.preventDefault();
-                            if ($scope.targetUrl) {
-                                isHref = true;
-                            } else {
-                                $scope.targetUrl = toState.name;
-                                isHref = false;
-                            }
-                        }
-                        ngDialog.openConfirm({template: "../common/ui-helper/views/saveConfirmation.html", scope: $scope});
+                    if (event) {
+                        event.preventDefault();
                     }
+                    ngDialog.openConfirm({template: "../common/ui-helper/views/saveConfirmation.html", scope: $scope});
                 }
             };
 

--- a/ui/app/registration/views/header.html
+++ b/ui/app/registration/views/header.html
@@ -1,6 +1,6 @@
 <header class="reg-header" ng-controller="NavigationController">
         <ul class="top-nav fl">
-            <a class="back-btn" accesskey="h" href="../home/index.html" ng-click="onHomeNavigate()" id="bahmniHome"><i class="fa fa-home"></i></a>
+            <a class="back-btn" accesskey="h" href="../home/index.html" ng-click="onHomeNavigate()"><i class="fa fa-home"></i></a>
             <li ng-repeat="extension in ::extensions">
                 <a ng-click="goTo(extension.url)" accesskey="{{::extension.shortcutKey | translate}}"><i class="{{::extension.icon}} fa fa-white small"></i>
                     <span class="nav-link" ng-bind-html="::extension | titleTranslate"></span></a>

--- a/ui/app/registration/views/header.html
+++ b/ui/app/registration/views/header.html
@@ -1,6 +1,6 @@
 <header class="reg-header" ng-controller="NavigationController">
         <ul class="top-nav fl">
-            <a class="back-btn" accesskey="h" href="../home/index.html" ng-click="homeNavigate()" id="bahmniHome"><i class="fa fa-home"></i></a>
+            <a class="back-btn" accesskey="h" href="../home/index.html" ng-click="onHomeNavigate()" id="bahmniHome"><i class="fa fa-home"></i></a>
             <li ng-repeat="extension in ::extensions">
                 <a ng-click="goTo(extension.url)" accesskey="{{::extension.shortcutKey | translate}}"><i class="{{::extension.icon}} fa fa-white small"></i>
                     <span class="nav-link" ng-bind-html="::extension | titleTranslate"></span></a>

--- a/ui/app/registration/views/header.html
+++ b/ui/app/registration/views/header.html
@@ -1,6 +1,6 @@
 <header class="reg-header" ng-controller="NavigationController">
         <ul class="top-nav fl">
-            <a class="back-btn" accesskey="h" href="../home/index.html"><i class="fa fa-home"></i></a>
+            <a class="back-btn" accesskey="h" href="../home/index.html" ng-click="homeNavigate()" id="bahmniHome"><i class="fa fa-home"></i></a>
             <li ng-repeat="extension in ::extensions">
                 <a ng-click="goTo(extension.url)" accesskey="{{::extension.shortcutKey | translate}}"><i class="{{::extension.icon}} fa fa-white small"></i>
                     <span class="nav-link" ng-bind-html="::extension | titleTranslate"></span></a>

--- a/ui/test/unit/registration/controllers/patientCommonController.spec.js
+++ b/ui/test/unit/registration/controllers/patientCommonController.spec.js
@@ -51,7 +51,7 @@ describe('PatientCommonController', function () {
 
     });
 
-    it('checks if the confirmation popup is prompted when the home button is clicked when config is true', function () {
+    it('checks that the confirmation popup is prompted when the home button is clicked and the config is enabled', function () {
         scope.showSaveConfirmDialogConfig = true;
         scope.onHomeNavigate = jasmine.createSpy("onHomeNavigate");
         scope.confirmationPrompt = jasmine.createSpy("confirmationPrompt");
@@ -64,7 +64,7 @@ describe('PatientCommonController', function () {
         expect(scope.confirmationPrompt).toHaveBeenCalled();
     });
 
-    it('checks if the confirmation popup is not prompted when the home button is clicked when config is false', function () {
+    it('checks that the confirmation popup is not prompted when the home button is clicked and the config is disabled', function () {
         scope.showSaveConfirmDialogConfig = false;
         scope.onHomeNavigate = jasmine.createSpy("onHomeNavigate");
         scope.confirmationPrompt = jasmine.createSpy("confirmationPrompt");

--- a/ui/test/unit/registration/controllers/patientCommonController.spec.js
+++ b/ui/test/unit/registration/controllers/patientCommonController.spec.js
@@ -53,27 +53,27 @@ describe('PatientCommonController', function () {
 
     it('checks if the confirmation popup is prompted when the home button is clicked when config is true', function () {
         scope.showSaveConfirmDialogConfig = true;
-        scope.homeNavigate = jasmine.createSpy("homeNavigate");
-        scope.naviConfirmBox = jasmine.createSpy("naviConfirmBox");
-        var element = angular.element("<a ng-click='homeNavigate()'>");
+        scope.onHomeNavigate = jasmine.createSpy("onHomeNavigate");
+        scope.confirmationPrompt = jasmine.createSpy("confirmationPrompt");
+        var element = angular.element("<a ng-click='onHomeNavigate()'>");
         var compiled = $compile(element)(scope);
         compiled.triggerHandler('click');
-        expect(scope.homeNavigate).toHaveBeenCalled();
+        expect(scope.onHomeNavigate).toHaveBeenCalled();
         expect(scope.showSaveConfirmDialogConfig).toBe(true);
-        scope.naviConfirmBox();
-        expect(scope.naviConfirmBox).toHaveBeenCalled();
+        scope.confirmationPrompt();
+        expect(scope.confirmationPrompt).toHaveBeenCalled();
     });
 
     it('checks if the confirmation popup is not prompted when the home button is clicked when config is false', function () {
         scope.showSaveConfirmDialogConfig = false;
-        scope.homeNavigate = jasmine.createSpy("homeNavigate");
-        scope.naviConfirmBox = jasmine.createSpy("naviConfirmBox");
-        var element = angular.element("<a ng-click='homeNavigate()'>");
+        scope.onHomeNavigate = jasmine.createSpy("onHomeNavigate");
+        scope.confirmationPrompt = jasmine.createSpy("confirmationPrompt");
+        var element = angular.element("<a ng-click='onHomeNavigate()'>");
         var compiled = $compile(element)(scope);
         compiled.triggerHandler('click');
-        expect(scope.homeNavigate).toHaveBeenCalled();
+        expect(scope.onHomeNavigate).toHaveBeenCalled();
         expect(scope.showSaveConfirmDialogConfig).not.toBe(true);
-        expect(scope.naviConfirmBox).not.toHaveBeenCalled();
+        expect(scope.confirmationPrompt).not.toHaveBeenCalled();
     });
 
     it("should make calls for reason for death global property and concept sets", function () {

--- a/ui/test/unit/registration/controllers/patientCommonController.spec.js
+++ b/ui/test/unit/registration/controllers/patientCommonController.spec.js
@@ -4,19 +4,21 @@ describe('PatientCommonController', function () {
 
     var $aController, $httpBackend, scope, appService, rootScope, patientAttributeService;
     var spinner = jasmine.createSpyObj('spinner', ['forPromise']);
+    var $compile;
 
-    beforeEach(module('bahmni.registration'));
+    beforeEach(module('bahmni.registration', 'ngDialog'));
 
     beforeEach(module(function ($provide) {
         $provide.value('patientAttributeService', {});
     }));
 
     beforeEach(
-        inject(function ($controller, _$httpBackend_, $rootScope) {
+        inject(function ($controller, _$httpBackend_, $rootScope, _$compile_) {
             $aController = $controller;
             $httpBackend = _$httpBackend_;
             scope = $rootScope.$new();
             rootScope = $rootScope;
+            $compile = _$compile_;
         })
     );
 
@@ -49,6 +51,30 @@ describe('PatientCommonController', function () {
 
     });
 
+    it('checks if the confirmation popup is prompted when the home button is clicked when config is true', function () {
+        scope.showSaveConfirmDialogConfig = true;
+        scope.homeNavigate = jasmine.createSpy("homeNavigate");
+        scope.naviConfirmBox = jasmine.createSpy("naviConfirmBox");
+        var element = angular.element("<a ng-click='homeNavigate()'>");
+        var compiled = $compile(element)(scope);
+        compiled.triggerHandler('click');
+        expect(scope.homeNavigate).toHaveBeenCalled();
+        expect(scope.showSaveConfirmDialogConfig).toBe(true);
+        scope.naviConfirmBox();
+        expect(scope.naviConfirmBox).toHaveBeenCalled();
+    });
+
+    it('checks if the confirmation popup is not prompted when the home button is clicked when config is false', function () {
+        scope.showSaveConfirmDialogConfig = false;
+        scope.homeNavigate = jasmine.createSpy("homeNavigate");
+        scope.naviConfirmBox = jasmine.createSpy("naviConfirmBox");
+        var element = angular.element("<a ng-click='homeNavigate()'>");
+        var compiled = $compile(element)(scope);
+        compiled.triggerHandler('click');
+        expect(scope.homeNavigate).toHaveBeenCalled();
+        expect(scope.showSaveConfirmDialogConfig).not.toBe(true);
+        expect(scope.naviConfirmBox).not.toHaveBeenCalled();
+    });
 
     it("should make calls for reason for death global property and concept sets", function () {
         $httpBackend.expectGET(Bahmni.Common.Constants.globalPropertyUrl);


### PR DESCRIPTION
1.A confirm box has been added when ever the user tries to navigate away from the patient registration screen.
2.The above prompt is enabled through the following config being set to true in registration/app.js: "showSaveConfirmDialog" : true
3. However "stateChangeStart" and "locationChangeStart" are not getting triggered for the Home button and preventing to leverage the above functionality.
4. The desired outcome is achievable by setting an "ng-click" attribute to the Home button and calling a function when the button is clicked.Earlier this was an "id" attribute and the code to handle it was a jquery function.Due to this,a particular Code Climate test was failing as it required plain Angular code and not jQuery. The solution would have been to use "angular.element" but calling the function which handles the Home button click from patient registration page was not possible using "angular.element" as it was possible using "(#id).click(function()......)" in jQuery. Hence, "ng-click" was used

5.Navigating away through

Clicking on Search button
URL change
Navigating away from patient registration page
Clicking the Chrome's back button triggers the confirmation prompt to appear as it does in 'clinical'.