### PR TITLE
BAH-462: Need not call API to fetch appointments when switching views…

### DIFF
--- a/ui/app/appointments/app.js
+++ b/ui/app/appointments/app.js
@@ -79,7 +79,9 @@ angular
                 url: '/calendar',
                 tabName: 'calendar',
                 params: {
-                    viewDate: null
+                    viewDate: null,
+                    getAppointments: true,
+                    appointmentData: null
                 },
                 views: {
                     'content@viewAppointments': {
@@ -127,7 +129,9 @@ angular
                 tabName: 'list',
                 params: {
                     viewDate: null,
-                    patient: null
+                    patient: null,
+                    getAppointments: true,
+                    appointmentData: null
                 },
                 views: {
                     'content@viewAppointments': {

--- a/ui/app/appointments/app.js
+++ b/ui/app/appointments/app.js
@@ -80,8 +80,8 @@ angular
                 tabName: 'calendar',
                 params: {
                     viewDate: null,
-                    getAppointments: true,
-                    appointmentData: null
+                    doFetchAppointmentsData: true,
+                    appointmentsData: null
                 },
                 views: {
                     'content@viewAppointments': {
@@ -130,8 +130,8 @@ angular
                 params: {
                     viewDate: null,
                     patient: null,
-                    getAppointments: true,
-                    appointmentData: null
+                    doFetchAppointmentsData: true,
+                    appointmentsData: null
                 },
                 views: {
                     'content@viewAppointments': {

--- a/ui/app/appointments/controllers/manage/allAppointmentsController.js
+++ b/ui/app/appointments/controllers/manage/allAppointmentsController.js
@@ -10,7 +10,7 @@ angular.module('bahmni.appointments')
             $scope.navigateTo = function (viewName) {
                 $scope.currentTab = viewName;
                 var path = 'home.manage.appointments.' + viewName;
-                $state.params.appointmentData = $rootScope.appointmentData;
+                $state.params.appointmentsData = $rootScope.appointmentsData;
                 $state.go(path, $state.params, {reload: false});
             };
 

--- a/ui/app/appointments/controllers/manage/allAppointmentsController.js
+++ b/ui/app/appointments/controllers/manage/allAppointmentsController.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('bahmni.appointments')
-    .controller('AllAppointmentsController', ['$scope', '$state', 'appService',
-        function ($scope, $state, appService) {
+    .controller('AllAppointmentsController', ['$scope', '$state', 'appService', '$rootScope',
+        function ($scope, $state, appService, $rootScope) {
             $scope.enableCalendarView = appService.getAppDescriptor().getConfigValue('enableCalendarView');
             $scope.isSearchEnabled = false;
             $scope.manageAppointmentPrivilege = Bahmni.Appointments.Constants.privilegeManageAppointments;
@@ -10,6 +10,7 @@ angular.module('bahmni.appointments')
             $scope.navigateTo = function (viewName) {
                 $scope.currentTab = viewName;
                 var path = 'home.manage.appointments.' + viewName;
+                $state.params.appointmentData = $rootScope.appointmentData;
                 $state.go(path, $state.params, {reload: false});
             };
 

--- a/ui/app/appointments/controllers/manage/calendar/appointmentsCalendarViewController.js
+++ b/ui/app/appointments/controllers/manage/calendar/appointmentsCalendarViewController.js
@@ -73,7 +73,7 @@ angular.module('bahmni.appointments')
                 return $state.params.filterParams;
             }, function (newValue, oldValue) {
                 if (newValue !== oldValue) {
-                    var filteredAppointments = appointmentsFilter($scope.allAppointmentsForDay || $state.params.appointmentData, $state.params.filterParams);
+                    var filteredAppointments = appointmentsFilter($scope.allAppointmentsForDay || $state.params.appointmentsData, $state.params.filterParams);
                     parseAppointments(filteredAppointments);
                 }
             }, true);
@@ -84,19 +84,19 @@ angular.module('bahmni.appointments')
                 var params = {forDate: viewDate};
                 $scope.$on('$stateChangeStart', function (event, toState, toParams) {
                     if (toState.tabName == 'list') {
-                        toParams.getAppointments = false;
+                        toParams.doFetchAppointmentsData = false;
                     }
                 });
-                if ($state.params.getAppointments) {
+                if ($state.params.doFetchAppointmentsData) {
                     return spinner.forPromise(appointmentsService.getAllAppointments(params).then(function (response) {
                         $scope.allAppointmentsForDay = response.data;
                         var filteredAppointments = appointmentsFilter($scope.allAppointmentsForDay, $state.params.filterParams);
-                        $rootScope.appointmentData = filteredAppointments;
+                        $rootScope.appointmentsData = filteredAppointments;
                         return parseAppointments(filteredAppointments);
                     }));
                 } else {
-                    var filteredAppointments = appointmentsFilter($state.params.appointmentData, $state.params.filterParams);
-                    $state.params.getAppointments = true;
+                    var filteredAppointments = appointmentsFilter($state.params.appointmentsData, $state.params.filterParams);
+                    $state.params.doFetchAppointmentsData = true;
                     return parseAppointments(filteredAppointments);
                 }
             };

--- a/ui/app/appointments/controllers/manage/calendar/appointmentsCalendarViewController.js
+++ b/ui/app/appointments/controllers/manage/calendar/appointmentsCalendarViewController.js
@@ -12,61 +12,63 @@ angular.module('bahmni.appointments')
             };
 
             var parseAppointments = function (allAppointments) {
-                var appointments = allAppointments.filter(function (appointment) {
-                    return appointment.status !== 'Cancelled';
-                });
-                var resources = _.chain(appointments)
-                    .filter(function (appointment) {
-                        return !_.isEmpty(appointment.provider);
-                    }).map(function (appointment) {
-                        return appointment.provider;
-                    }).uniqBy('name')
-                    .map(function (provider) {
-                        return {id: provider.name, title: provider.name, provider: provider};
-                    }).sortBy(function (provider) {
-                        return provider.id && provider.id.toLowerCase();
-                    })
-                    .value();
-
-                var hasAppointmentsWithNoProvidersSpecified = _.find(appointments, function (appointment) {
-                    return _.isEmpty(appointment.provider);
-                });
-
-                if (hasAppointmentsWithNoProvidersSpecified) {
-                    resources.push({
-                        id: $translate.instant("NO_PROVIDER_COLUMN_KEY"),
-                        title: $translate.instant("NO_PROVIDER_COLUMN_KEY"),
-                        provider: {name: $translate.instant("NO_PROVIDER_COLUMN_KEY"), display: $translate.instant("NO_PROVIDER_COLUMN_KEY"), uuid: 'no-provider-uuid'}
+                if (allAppointments) {
+                    var appointments = allAppointments.filter(function (appointment) {
+                        return appointment.status !== 'Cancelled';
                     });
-                }
+                    var resources = _.chain(appointments)
+                        .filter(function (appointment) {
+                            return !_.isEmpty(appointment.provider);
+                        }).map(function (appointment) {
+                            return appointment.provider;
+                        }).uniqBy('name')
+                        .map(function (provider) {
+                            return {id: provider.name, title: provider.name, provider: provider};
+                        }).sortBy(function (provider) {
+                            return provider.id && provider.id.toLowerCase();
+                        })
+                        .value();
 
-                var events = [];
-                appointments.reduce(function (result, appointment) {
-                    var event = {};
-                    event.resourceId = appointment.provider ? appointment.provider.name : $translate.instant("NO_PROVIDER_COLUMN_KEY");
-                    event.start = appointment.startDateTime;
-                    event.end = appointment.endDateTime;
-                    event.color = appointment.service.color;
-                    event.serviceName = appointment.service.name;
-                    var existingEvent = _.find(result, event);
-                    var patientName = appointment.patient.name + " (" + appointment.patient.identifier + ")";
-                    var isBedAssigned = appointment.additionalInfo && appointment.additionalInfo.BED_NUMBER_KEY;
-                    if (existingEvent) {
-                        existingEvent.title = [existingEvent.title, patientName].join(', ');
-                        existingEvent.className = 'appointmentIcons multiplePatients' + (isBedAssigned ? ' bed-accom' : '');
-                        existingEvent.appointments.push(appointment);
-                    } else {
-                        event.title = patientName;
-                        event.className = 'appointmentIcons ' + appointment.status + (isBedAssigned ? ' bed-accom' : '');
-                        event.appointments = [];
-                        event.appointments.push(appointment);
-                        result.push(event);
+                    var hasAppointmentsWithNoProvidersSpecified = _.find(appointments, function (appointment) {
+                        return _.isEmpty(appointment.provider);
+                    });
+
+                    if (hasAppointmentsWithNoProvidersSpecified) {
+                        resources.push({
+                            id: $translate.instant("NO_PROVIDER_COLUMN_KEY"),
+                            title: $translate.instant("NO_PROVIDER_COLUMN_KEY"),
+                            provider: {name: $translate.instant("NO_PROVIDER_COLUMN_KEY"), display: $translate.instant("NO_PROVIDER_COLUMN_KEY"), uuid: 'no-provider-uuid'}
+                        });
                     }
-                    return result;
-                }, events);
 
-                $scope.providerAppointments = {resources: resources, events: events};
-                $scope.shouldReload = true;
+                    var events = [];
+                    appointments.reduce(function (result, appointment) {
+                        var event = {};
+                        event.resourceId = appointment.provider ? appointment.provider.name : $translate.instant("NO_PROVIDER_COLUMN_KEY");
+                        event.start = appointment.startDateTime;
+                        event.end = appointment.endDateTime;
+                        event.color = appointment.service.color;
+                        event.serviceName = appointment.service.name;
+                        var existingEvent = _.find(result, event);
+                        var patientName = appointment.patient.name + " (" + appointment.patient.identifier + ")";
+                        var isBedAssigned = appointment.additionalInfo && appointment.additionalInfo.BED_NUMBER_KEY;
+                        if (existingEvent) {
+                            existingEvent.title = [existingEvent.title, patientName].join(', ');
+                            existingEvent.className = 'appointmentIcons multiplePatients' + (isBedAssigned ? ' bed-accom' : '');
+                            existingEvent.appointments.push(appointment);
+                        } else {
+                            event.title = patientName;
+                            event.className = 'appointmentIcons ' + appointment.status + (isBedAssigned ? ' bed-accom' : '');
+                            event.appointments = [];
+                            event.appointments.push(appointment);
+                            result.push(event);
+                        }
+                        return result;
+                    }, events);
+
+                    $scope.providerAppointments = {resources: resources, events: events};
+                    $scope.shouldReload = true;
+                }
             };
 
             $scope.$watch(function () {
@@ -74,7 +76,9 @@ angular.module('bahmni.appointments')
             }, function (newValue, oldValue) {
                 if (newValue !== oldValue) {
                     var filteredAppointments = appointmentsFilter($scope.allAppointmentsForDay || $state.params.appointmentsData, $state.params.filterParams);
-                    parseAppointments(filteredAppointments);
+                    if (filteredAppointments) {
+                        parseAppointments(filteredAppointments);
+                    }
                 }
             }, true);
 

--- a/ui/app/appointments/controllers/manage/list/appointmentsListViewController.js
+++ b/ui/app/appointments/controllers/manage/list/appointmentsListViewController.js
@@ -40,10 +40,21 @@ angular.module('bahmni.appointments')
                 $stateParams.viewDate = viewDate;
                 $scope.selectedAppointment = undefined;
                 var params = {forDate: viewDate};
-                spinner.forPromise(appointmentsService.getAllAppointments(params).then(function (response) {
-                    $scope.appointments = response.data;
-                    $scope.filteredAppointments = appointmentsFilter($scope.appointments, $stateParams.filterParams);
-                }));
+                $scope.$on('$stateChangeStart', function (event, toState, toParams) {
+                    if (toState.tabName == 'calendar') {
+                        toParams.getAppointments = false;
+                    }
+                });
+                if ($state.params.getAppointments) {
+                    spinner.forPromise(appointmentsService.getAllAppointments(params).then(function (response) {
+                        $scope.appointments = response.data;
+                        $scope.filteredAppointments = appointmentsFilter($scope.appointments, $stateParams.filterParams);
+                        $rootScope.appointmentData = $scope.filteredAppointments;
+                    }));
+                } else {
+                    $scope.filteredAppointments = appointmentsFilter($state.params.appointmentData, $stateParams.filterParams);
+                    $state.params.getAppointments = true;
+                }
             };
 
             $scope.displaySearchedPatient = function (appointments) {
@@ -108,7 +119,7 @@ angular.module('bahmni.appointments')
                 return $stateParams.filterParams;
             }, function (newValue, oldValue) {
                 if (newValue !== oldValue) {
-                    $scope.filteredAppointments = appointmentsFilter($scope.appointments, $stateParams.filterParams);
+                    $scope.filteredAppointments = appointmentsFilter($scope.appointments || $state.params.appointmentData, $stateParams.filterParams);
                 }
             }, true);
 

--- a/ui/app/appointments/controllers/manage/list/appointmentsListViewController.js
+++ b/ui/app/appointments/controllers/manage/list/appointmentsListViewController.js
@@ -42,18 +42,18 @@ angular.module('bahmni.appointments')
                 var params = {forDate: viewDate};
                 $scope.$on('$stateChangeStart', function (event, toState, toParams) {
                     if (toState.tabName == 'calendar') {
-                        toParams.getAppointments = false;
+                        toParams.doFetchAppointmentsData = false;
                     }
                 });
-                if ($state.params.getAppointments) {
+                if ($state.params.doFetchAppointmentsData) {
                     spinner.forPromise(appointmentsService.getAllAppointments(params).then(function (response) {
                         $scope.appointments = response.data;
                         $scope.filteredAppointments = appointmentsFilter($scope.appointments, $stateParams.filterParams);
-                        $rootScope.appointmentData = $scope.filteredAppointments;
+                        $rootScope.appointmentsData = $scope.filteredAppointments;
                     }));
                 } else {
-                    $scope.filteredAppointments = appointmentsFilter($state.params.appointmentData, $stateParams.filterParams);
-                    $state.params.getAppointments = true;
+                    $scope.filteredAppointments = appointmentsFilter($state.params.appointmentsData, $stateParams.filterParams);
+                    $state.params.doFetchAppointmentsData = true;
                 }
             };
 
@@ -119,7 +119,7 @@ angular.module('bahmni.appointments')
                 return $stateParams.filterParams;
             }, function (newValue, oldValue) {
                 if (newValue !== oldValue) {
-                    $scope.filteredAppointments = appointmentsFilter($scope.appointments || $state.params.appointmentData, $stateParams.filterParams);
+                    $scope.filteredAppointments = appointmentsFilter($scope.appointments || $state.params.appointmentsData, $stateParams.filterParams);
                 }
             }, true);
 

--- a/ui/test/unit/appointments/controllers/manage/calendar/appointmentsCalendarViewController.spec.js
+++ b/ui/test/unit/appointments/controllers/manage/calendar/appointmentsCalendarViewController.spec.js
@@ -1,14 +1,15 @@
 'use strict';
 
 describe('AppointmentsCalendarViewController', function () {
-    var controller, scope, spinner, appointmentsService, translate, stateParams;
+    var controller, scope, spinner, appointmentsService, translate, stateParams, state;
 
     beforeEach(function () {
         module('bahmni.appointments');
-        inject(function ($controller, $rootScope, $stateParams) {
+        inject(function ($controller, $rootScope, $stateParams, $state) {
             controller = $controller;
             scope = $rootScope.$new();
             stateParams = $stateParams;
+			state = $state;
             spinner = jasmine.createSpyObj('spinner', ['forPromise']);
             spinner.forPromise.and.callFake(function () {
                 return {
@@ -38,11 +39,12 @@ describe('AppointmentsCalendarViewController', function () {
 
     it('should get appointments for date', function () {
         var viewDate = new Date('1970-01-01T11:30:00.000Z');
+		state.params = {getAppointments: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: []}));
         scope.getAppointmentsForDate(viewDate).then(function () {
             expect(scope.shouldReload).toBeFalsy();
             expect(stateParams.viewDate).toEqual(viewDate);
-        });
+        }); 
         expect(appointmentsService.getAllAppointments).toHaveBeenCalledWith({forDate: viewDate});
         expect(spinner.forPromise).toHaveBeenCalled();
     });
@@ -86,6 +88,7 @@ describe('AppointmentsCalendarViewController', function () {
             "status": "Scheduled",
             "comments": null
         }]}));
+		state.params = {getAppointments: true};
         scope.getAppointmentsForDate(viewDate);
         expect(scope.providerAppointments.resources.length).toBe(1);
         expect(scope.providerAppointments.resources[0].id).toBe('No provider appointments');
@@ -138,6 +141,7 @@ describe('AppointmentsCalendarViewController', function () {
                 "status": "CheckedIn"
             }
         ];
+		state.params = {getAppointments: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: allAppointments}));
         var viewDate = new Date('1970-01-01T11:30:00.000Z');
         scope.getAppointmentsForDate(viewDate);
@@ -217,6 +221,7 @@ describe('AppointmentsCalendarViewController', function () {
                 }
             }
         ];
+		state.params = {getAppointments: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: allAppointments}));
         var viewDate = new Date('1970-01-01T11:30:00.000Z');
         scope.getAppointmentsForDate(viewDate);
@@ -283,6 +288,7 @@ describe('AppointmentsCalendarViewController', function () {
                 "status": "CheckedIn"
             }
         ];
+		state.params = {getAppointments: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: allAppointments}));
         var viewDate = new Date('1970-01-01T11:30:00.000Z');
         scope.getAppointmentsForDate(viewDate);
@@ -353,6 +359,7 @@ describe('AppointmentsCalendarViewController', function () {
                 "status": "Scheduled"
             }
         ];
+		state.params = {getAppointments: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: allAppointments}));
         var viewDate = new Date('1970-01-01T11:30:00.000Z');
         scope.getAppointmentsForDate(viewDate);
@@ -405,6 +412,7 @@ describe('AppointmentsCalendarViewController', function () {
             "status": "Scheduled",
             "comments": null
         }];
+		state.params = {getAppointments: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: appointments}));
         createController();
         scope.getAppointmentsForDate("Wed Sep 06 2017 00:00:00 GMT+0530 (IST)");
@@ -451,6 +459,7 @@ describe('AppointmentsCalendarViewController', function () {
                 "status": "Scheduled",
                 "comments": null
             }];
+		state.params = {getAppointments: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: appointments}));
         createController();
         scope.getAppointmentsForDate("Wed Sep 06 2017 00:00:00 GMT+0530 (IST)");

--- a/ui/test/unit/appointments/controllers/manage/calendar/appointmentsCalendarViewController.spec.js
+++ b/ui/test/unit/appointments/controllers/manage/calendar/appointmentsCalendarViewController.spec.js
@@ -38,10 +38,12 @@ describe('AppointmentsCalendarViewController', function () {
     });
 
     it('should not fetch appointments when doFetchAppointmentsData is set to false', function () {
-        state.params = {doFetchAppointmentsData: false}; 
+        state.params = {doFetchAppointmentsData: false};
+        appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({}));
+        var viewDate = new Date('1970-01-01T11:30:00.000Z');
+        scope.getAppointmentsForDate(viewDate);
         expect(appointmentsService.getAllAppointments).not.toHaveBeenCalled();
         expect(spinner.forPromise).not.toHaveBeenCalled();
-        
     });
 
     it('should get appointments for date', function () {

--- a/ui/test/unit/appointments/controllers/manage/calendar/appointmentsCalendarViewController.spec.js
+++ b/ui/test/unit/appointments/controllers/manage/calendar/appointmentsCalendarViewController.spec.js
@@ -9,7 +9,7 @@ describe('AppointmentsCalendarViewController', function () {
             controller = $controller;
             scope = $rootScope.$new();
             stateParams = $stateParams;
-			state = $state;
+            state = $state;
             spinner = jasmine.createSpyObj('spinner', ['forPromise']);
             spinner.forPromise.and.callFake(function () {
                 return {
@@ -37,9 +37,16 @@ describe('AppointmentsCalendarViewController', function () {
         createController();
     });
 
+    it('should not fetch appointments when doFetchAppointmentsData is set to false', function () {
+        state.params = {doFetchAppointmentsData: false}; 
+        expect(appointmentsService.getAllAppointments).not.toHaveBeenCalled();
+        expect(spinner.forPromise).not.toHaveBeenCalled();
+        
+    });
+
     it('should get appointments for date', function () {
         var viewDate = new Date('1970-01-01T11:30:00.000Z');
-		state.params = {doFetchAppointmentsData: true};
+        state.params = {doFetchAppointmentsData: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: []}));
         scope.getAppointmentsForDate(viewDate).then(function () {
             expect(scope.shouldReload).toBeFalsy();
@@ -88,7 +95,7 @@ describe('AppointmentsCalendarViewController', function () {
             "status": "Scheduled",
             "comments": null
         }]}));
-		state.params = {doFetchAppointmentsData: true};
+        state.params = {doFetchAppointmentsData: true};
         scope.getAppointmentsForDate(viewDate);
         expect(scope.providerAppointments.resources.length).toBe(1);
         expect(scope.providerAppointments.resources[0].id).toBe('No provider appointments');
@@ -141,7 +148,7 @@ describe('AppointmentsCalendarViewController', function () {
                 "status": "CheckedIn"
             }
         ];
-		state.params = {doFetchAppointmentsData: true};
+        state.params = {doFetchAppointmentsData: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: allAppointments}));
         var viewDate = new Date('1970-01-01T11:30:00.000Z');
         scope.getAppointmentsForDate(viewDate);
@@ -221,7 +228,7 @@ describe('AppointmentsCalendarViewController', function () {
                 }
             }
         ];
-		state.params = {doFetchAppointmentsData: true};
+        state.params = {doFetchAppointmentsData: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: allAppointments}));
         var viewDate = new Date('1970-01-01T11:30:00.000Z');
         scope.getAppointmentsForDate(viewDate);
@@ -288,7 +295,7 @@ describe('AppointmentsCalendarViewController', function () {
                 "status": "CheckedIn"
             }
         ];
-		state.params = {doFetchAppointmentsData: true};
+        state.params = {doFetchAppointmentsData: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: allAppointments}));
         var viewDate = new Date('1970-01-01T11:30:00.000Z');
         scope.getAppointmentsForDate(viewDate);
@@ -359,7 +366,7 @@ describe('AppointmentsCalendarViewController', function () {
                 "status": "Scheduled"
             }
         ];
-		state.params = {doFetchAppointmentsData: true};
+        state.params = {doFetchAppointmentsData: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: allAppointments}));
         var viewDate = new Date('1970-01-01T11:30:00.000Z');
         scope.getAppointmentsForDate(viewDate);
@@ -412,7 +419,7 @@ describe('AppointmentsCalendarViewController', function () {
             "status": "Scheduled",
             "comments": null
         }];
-		state.params = {doFetchAppointmentsData: true};
+        state.params = {doFetchAppointmentsData: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: appointments}));
         createController();
         scope.getAppointmentsForDate("Wed Sep 06 2017 00:00:00 GMT+0530 (IST)");
@@ -459,7 +466,7 @@ describe('AppointmentsCalendarViewController', function () {
                 "status": "Scheduled",
                 "comments": null
             }];
-		state.params = {doFetchAppointmentsData: true};
+        state.params = {doFetchAppointmentsData: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: appointments}));
         createController();
         scope.getAppointmentsForDate("Wed Sep 06 2017 00:00:00 GMT+0530 (IST)");

--- a/ui/test/unit/appointments/controllers/manage/calendar/appointmentsCalendarViewController.spec.js
+++ b/ui/test/unit/appointments/controllers/manage/calendar/appointmentsCalendarViewController.spec.js
@@ -39,7 +39,7 @@ describe('AppointmentsCalendarViewController', function () {
 
     it('should get appointments for date', function () {
         var viewDate = new Date('1970-01-01T11:30:00.000Z');
-		state.params = {getAppointments: true};
+		state.params = {doFetchAppointmentsData: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: []}));
         scope.getAppointmentsForDate(viewDate).then(function () {
             expect(scope.shouldReload).toBeFalsy();
@@ -88,7 +88,7 @@ describe('AppointmentsCalendarViewController', function () {
             "status": "Scheduled",
             "comments": null
         }]}));
-		state.params = {getAppointments: true};
+		state.params = {doFetchAppointmentsData: true};
         scope.getAppointmentsForDate(viewDate);
         expect(scope.providerAppointments.resources.length).toBe(1);
         expect(scope.providerAppointments.resources[0].id).toBe('No provider appointments');
@@ -141,7 +141,7 @@ describe('AppointmentsCalendarViewController', function () {
                 "status": "CheckedIn"
             }
         ];
-		state.params = {getAppointments: true};
+		state.params = {doFetchAppointmentsData: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: allAppointments}));
         var viewDate = new Date('1970-01-01T11:30:00.000Z');
         scope.getAppointmentsForDate(viewDate);
@@ -221,7 +221,7 @@ describe('AppointmentsCalendarViewController', function () {
                 }
             }
         ];
-		state.params = {getAppointments: true};
+		state.params = {doFetchAppointmentsData: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: allAppointments}));
         var viewDate = new Date('1970-01-01T11:30:00.000Z');
         scope.getAppointmentsForDate(viewDate);
@@ -288,7 +288,7 @@ describe('AppointmentsCalendarViewController', function () {
                 "status": "CheckedIn"
             }
         ];
-		state.params = {getAppointments: true};
+		state.params = {doFetchAppointmentsData: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: allAppointments}));
         var viewDate = new Date('1970-01-01T11:30:00.000Z');
         scope.getAppointmentsForDate(viewDate);
@@ -359,7 +359,7 @@ describe('AppointmentsCalendarViewController', function () {
                 "status": "Scheduled"
             }
         ];
-		state.params = {getAppointments: true};
+		state.params = {doFetchAppointmentsData: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: allAppointments}));
         var viewDate = new Date('1970-01-01T11:30:00.000Z');
         scope.getAppointmentsForDate(viewDate);
@@ -412,7 +412,7 @@ describe('AppointmentsCalendarViewController', function () {
             "status": "Scheduled",
             "comments": null
         }];
-		state.params = {getAppointments: true};
+		state.params = {doFetchAppointmentsData: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: appointments}));
         createController();
         scope.getAppointmentsForDate("Wed Sep 06 2017 00:00:00 GMT+0530 (IST)");
@@ -459,7 +459,7 @@ describe('AppointmentsCalendarViewController', function () {
                 "status": "Scheduled",
                 "comments": null
             }];
-		state.params = {getAppointments: true};
+		state.params = {doFetchAppointmentsData: true};
         appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: appointments}));
         createController();
         scope.getAppointmentsForDate("Wed Sep 06 2017 00:00:00 GMT+0530 (IST)");

--- a/ui/test/unit/appointments/controllers/manage/list/appointmentsListViewController.spec.js
+++ b/ui/test/unit/appointments/controllers/manage/list/appointmentsListViewController.spec.js
@@ -94,7 +94,7 @@ describe('AppointmentsListViewController', function () {
     it('should get appointments for date', function () {
         createController();
         var viewDate = new Date('1970-01-01T11:30:00.000Z');
-		$state.params = {getAppointments: true};
+        $state.params = {doFetchAppointmentsData: true};
         scope.getAppointmentsForDate(viewDate);
         expect(stateparams.viewDate).toEqual(viewDate);
         expect(appointmentsService.getAllAppointments).toHaveBeenCalledWith({forDate: viewDate});
@@ -225,7 +225,7 @@ describe('AppointmentsListViewController', function () {
         stateparams.filterParams = {serviceUuids: ["02666cc6-5f3e-4920-856d-ab7e28d3dbdb"]};
         createController();
         var viewDate = new Date('2017-08-28T11:30:00.000Z');
-		$state.params = {getAppointments: true};
+		$state.params = {doFetchAppointmentsData: true};
         scope.getAppointmentsForDate(viewDate);
         expect(scope.appointments).toBe(appointments);
         expect(scope.filteredAppointments.length).toEqual(1);
@@ -331,7 +331,7 @@ describe('AppointmentsListViewController', function () {
         };
         createController();
         var viewDate = new Date('2017-08-28T11:30:00.000Z');
-		$state.params = {getAppointments: true};
+		$state.params = {doFetchAppointmentsData: true};
         scope.getAppointmentsForDate(viewDate);
         expect(scope.appointments).toBe(appointments);
         expect(scope.searchedPatient).toBeFalsy();
@@ -503,7 +503,7 @@ describe('AppointmentsListViewController', function () {
             _appointmentsFilter.and.callFake(function () {
                 return appointments;
             });
-			$state.params = {getAppointments: true};
+			$state.params = {doFetchAppointmentsData: true};
             appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: appointments}));
             createController();
             scope.getAppointmentsForDate(new Date(200000));
@@ -632,7 +632,7 @@ describe('AppointmentsListViewController', function () {
                 }
             };
             var appointments = [appointment1, appointment2];
-			$state.params = {getAppointments: true};
+			$state.params = {doFetchAppointmentsData: true};
             appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: appointments}));
             _appointmentsFilter.and.callFake(function () {
                 return appointments;
@@ -718,7 +718,7 @@ describe('AppointmentsListViewController', function () {
         it('should filter the appointments on change of filter params', function () {
             var appointment = {patient: {name: 'patient'}};
             scope.appointments = [appointment];
-			$state.params = {getAppointments: true};
+			$state.params = {doFetchAppointmentsData: true};
             _appointmentsFilter.and.callFake(function () {
                 return appointment;
             });

--- a/ui/test/unit/appointments/controllers/manage/list/appointmentsListViewController.spec.js
+++ b/ui/test/unit/appointments/controllers/manage/list/appointmentsListViewController.spec.js
@@ -94,6 +94,7 @@ describe('AppointmentsListViewController', function () {
     it('should get appointments for date', function () {
         createController();
         var viewDate = new Date('1970-01-01T11:30:00.000Z');
+		$state.params = {getAppointments: true};
         scope.getAppointmentsForDate(viewDate);
         expect(stateparams.viewDate).toEqual(viewDate);
         expect(appointmentsService.getAllAppointments).toHaveBeenCalledWith({forDate: viewDate});
@@ -224,6 +225,7 @@ describe('AppointmentsListViewController', function () {
         stateparams.filterParams = {serviceUuids: ["02666cc6-5f3e-4920-856d-ab7e28d3dbdb"]};
         createController();
         var viewDate = new Date('2017-08-28T11:30:00.000Z');
+		$state.params = {getAppointments: true};
         scope.getAppointmentsForDate(viewDate);
         expect(scope.appointments).toBe(appointments);
         expect(scope.filteredAppointments.length).toEqual(1);
@@ -329,6 +331,7 @@ describe('AppointmentsListViewController', function () {
         };
         createController();
         var viewDate = new Date('2017-08-28T11:30:00.000Z');
+		$state.params = {getAppointments: true};
         scope.getAppointmentsForDate(viewDate);
         expect(scope.appointments).toBe(appointments);
         expect(scope.searchedPatient).toBeFalsy();
@@ -500,6 +503,7 @@ describe('AppointmentsListViewController', function () {
             _appointmentsFilter.and.callFake(function () {
                 return appointments;
             });
+			$state.params = {getAppointments: true};
             appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: appointments}));
             createController();
             scope.getAppointmentsForDate(new Date(200000));
@@ -628,6 +632,7 @@ describe('AppointmentsListViewController', function () {
                 }
             };
             var appointments = [appointment1, appointment2];
+			$state.params = {getAppointments: true};
             appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: appointments}));
             _appointmentsFilter.and.callFake(function () {
                 return appointments;
@@ -713,6 +718,7 @@ describe('AppointmentsListViewController', function () {
         it('should filter the appointments on change of filter params', function () {
             var appointment = {patient: {name: 'patient'}};
             scope.appointments = [appointment];
+			$state.params = {getAppointments: true};
             _appointmentsFilter.and.callFake(function () {
                 return appointment;
             });

--- a/ui/test/unit/appointments/controllers/manage/list/appointmentsListViewController.spec.js
+++ b/ui/test/unit/appointments/controllers/manage/list/appointmentsListViewController.spec.js
@@ -94,6 +94,8 @@ describe('AppointmentsListViewController', function () {
     it('should not fetch appointments when doFetchAppointmentsData is set to false', function () {
         $state.params = {doFetchAppointmentsData: false};
         createController();
+        var viewDate = new Date('1970-01-01T11:30:00.000Z');
+        scope.getAppointmentsForDate(viewDate);
         expect(appointmentsService.getAllAppointments).not.toHaveBeenCalled();
         expect(spinner.forPromise).not.toHaveBeenCalled();
     });

--- a/ui/test/unit/appointments/controllers/manage/list/appointmentsListViewController.spec.js
+++ b/ui/test/unit/appointments/controllers/manage/list/appointmentsListViewController.spec.js
@@ -91,6 +91,13 @@ describe('AppointmentsListViewController', function () {
         expect(spinner.forPromise).not.toHaveBeenCalled();
     });
 
+    it('should not fetch appointments when doFetchAppointmentsData is set to false', function () {
+        $state.params = {doFetchAppointmentsData: false};
+        createController();
+        expect(appointmentsService.getAllAppointments).not.toHaveBeenCalled();
+        expect(spinner.forPromise).not.toHaveBeenCalled();
+    });
+
     it('should get appointments for date', function () {
         createController();
         var viewDate = new Date('1970-01-01T11:30:00.000Z');
@@ -225,7 +232,7 @@ describe('AppointmentsListViewController', function () {
         stateparams.filterParams = {serviceUuids: ["02666cc6-5f3e-4920-856d-ab7e28d3dbdb"]};
         createController();
         var viewDate = new Date('2017-08-28T11:30:00.000Z');
-		$state.params = {doFetchAppointmentsData: true};
+        $state.params = {doFetchAppointmentsData: true};
         scope.getAppointmentsForDate(viewDate);
         expect(scope.appointments).toBe(appointments);
         expect(scope.filteredAppointments.length).toEqual(1);
@@ -331,7 +338,7 @@ describe('AppointmentsListViewController', function () {
         };
         createController();
         var viewDate = new Date('2017-08-28T11:30:00.000Z');
-		$state.params = {doFetchAppointmentsData: true};
+        $state.params = {doFetchAppointmentsData: true};
         scope.getAppointmentsForDate(viewDate);
         expect(scope.appointments).toBe(appointments);
         expect(scope.searchedPatient).toBeFalsy();
@@ -503,7 +510,7 @@ describe('AppointmentsListViewController', function () {
             _appointmentsFilter.and.callFake(function () {
                 return appointments;
             });
-			$state.params = {doFetchAppointmentsData: true};
+            $state.params = {doFetchAppointmentsData: true};
             appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: appointments}));
             createController();
             scope.getAppointmentsForDate(new Date(200000));
@@ -632,7 +639,7 @@ describe('AppointmentsListViewController', function () {
                 }
             };
             var appointments = [appointment1, appointment2];
-			$state.params = {doFetchAppointmentsData: true};
+            $state.params = {doFetchAppointmentsData: true};
             appointmentsService.getAllAppointments.and.returnValue(specUtil.simplePromise({data: appointments}));
             _appointmentsFilter.and.callFake(function () {
                 return appointments;
@@ -718,7 +725,7 @@ describe('AppointmentsListViewController', function () {
         it('should filter the appointments on change of filter params', function () {
             var appointment = {patient: {name: 'patient'}};
             scope.appointments = [appointment];
-			$state.params = {doFetchAppointmentsData: true};
+            $state.params = {doFetchAppointmentsData: true};
             _appointmentsFilter.and.callFake(function () {
                 return appointment;
             });


### PR DESCRIPTION
… (list to calendar or vice versa)

Link to Jira Card: https://bahmni.atlassian.net/browse/BAH-462

### Changes:

- A new boolean flag is introduced stating whether appointment data should be re-fetched or not.
New Appointment data is only fetched when the date is changed and not when the view is changed.

- Once the appointment data is retrieved the same data is used by both "List" and "Calender" view.

- For achieving this,I have stored the appointment data in the `$rootScope` which is then passed as a state param between "Calender" and "List" View and based on the value of the boolean variable, it is decided whether to use the stored data or call the API again

-  Time taken while switching between List and Calendar views is significantly lower after achieving the above functionality.

