### PR TITLE
BAH-688, BAH-689 | Fix - Provider column sortable; Views do not show appointments for Removed/Cancelled provider responses 

### DIFF
--- a/ui/app/appointments/constants.js
+++ b/ui/app/appointments/constants.js
@@ -27,7 +27,9 @@ Bahmni.Appointments.Constants = (function () {
         regexForTime: /^(?:(?:1[0-2]|0?[1-9]):[0-5]\d\s*[AaPp][Mm])?$/,
         privilegeManageAppointments: 'app:appointments:manageAppointmentsTab',
         privilegeForAdmin: 'app:appointments:adminTab',
-        availableForAppointments: 'Available for appointments'
+        availableForAppointments: 'Available for appointments',
+        providerResponses: { ACCEPTED: "ACCEPTED", REJECTED: "REJECTED", TENTATIVE: "TENTATIVE", CANCELLED: "CANCELLED", AWAITING: "AWAITING" }
+
     };
 })();
 

--- a/ui/app/appointments/controllers/manage/appointmentsCreateController.js
+++ b/ui/app/appointments/controllers/manage/appointmentsCreateController.js
@@ -50,7 +50,9 @@ angular.module('bahmni.appointments')
 
             $scope.allowProviderAddition = function () {
                 if ($scope.appointment.providers != undefined) {
-                    return $scope.appointment.providers.length < $scope.maxAppointmentProviders;
+                    return $scope.appointment.providers.filter(function (p) {
+                        return p.response !== Bahmni.Appointments.Constants.providerResponses.CANCELLED;
+                    }).length < $scope.maxAppointmentProviders;
                 } else {
                     return $scope.maxAppointmentProviders > 0;
                 }
@@ -69,11 +71,15 @@ angular.module('bahmni.appointments')
                     if (pList.length === 0) {
                         var p = {
                             uuid: $scope.appointment.newProvider.uuid,
-                            response: "ACCEPTED",
+                            response: Bahmni.Appointments.Constants.providerResponses.ACCEPTED,
                             name: $scope.appointment.newProvider.name || $scope.appointment.newProvider.person.display,
                             comments: null
                         };
                         $scope.appointment.providers.push(p);
+                    }
+
+                    if (pList.length === 1) {
+                        pList[0].response = Bahmni.Appointments.Constants.providerResponses.ACCEPTED;
                     }
                 }
 

--- a/ui/app/appointments/controllers/manage/list/appointmentsListViewController.js
+++ b/ui/app/appointments/controllers/manage/list/appointmentsListViewController.js
@@ -198,11 +198,26 @@ angular.module('bahmni.appointments')
                     });
                     sortColumn = "additionalInformation";
                 }
+
                 var emptyObjects = _.filter($scope.filteredAppointments, function (appointment) {
                     return !_.property(sortColumn)(appointment);
                 });
+
+                if (sortColumn === "provider.name") {
+                    emptyObjects = $scope.filteredAppointments.filter(function (fa) {
+                        return _.every(fa.providers, {"response": Bahmni.Appointments.Constants.providerResponses.CANCELLED }) || _.isEmpty(fa.providers);
+                    });
+                }
+
                 var nonEmptyObjects = _.difference($scope.filteredAppointments, emptyObjects);
                 var sortedNonEmptyObjects = _.sortBy(nonEmptyObjects, function (appointment) {
+                    if (sortColumn === "provider.name") {
+                        var firstProvider = appointment.providers.find(function (p) {
+                            return p.response !== Bahmni.Appointments.Constants.providerResponses.CANCELLED;
+                        });
+                        return firstProvider.name.toLowerCase();
+                    }
+
                     if (angular.isNumber(_.get(appointment, sortColumn))) {
                         return _.get(appointment, sortColumn);
                     }

--- a/ui/app/appointments/models/appointment.js
+++ b/ui/app/appointments/models/appointment.js
@@ -20,7 +20,7 @@ Bahmni.Appointments.Appointment = (function () {
                     if (p.uuid != undefined) {
                         providerList.push({
                             uuid: p.uuid,
-                            response: "ACCEPTED",
+                            response: p.response,
                             comments: p.comments
                         });
                     }

--- a/ui/test/unit/appointments/controllers/manage/list/appointmentsListViewController.spec.js
+++ b/ui/test/unit/appointments/controllers/manage/list/appointmentsListViewController.spec.js
@@ -164,7 +164,6 @@ describe('AppointmentsListViewController', function () {
                 "creatorName": null
             },
             "serviceType": null,
-            "provider": null,
             "location": null,
             "startDateTime": 1503891000000,
             "endDateTime": 1503900900000,
@@ -194,7 +193,6 @@ describe('AppointmentsListViewController', function () {
                 "creatorName": null
             },
             "serviceType": null,
-            "provider": null,
             "location": null,
             "startDateTime": 1503887400000,
             "endDateTime": 1503889200000,
@@ -224,7 +222,7 @@ describe('AppointmentsListViewController', function () {
                 "creatorName": null
             },
             "serviceType": null,
-            "provider": {"name": "Super Man", "uuid": "c1c26908-3f10-11e4-adec-0800271c1b75"},
+            "providers": [{"name": "Super Man", "uuid": "c1c26908-3f10-11e4-adec-0800271c1b75", "response": "ACCEPTED"}],
             "location": null,
             "startDateTime": 1503923400000,
             "endDateTime": 1503925200000,
@@ -267,7 +265,6 @@ describe('AppointmentsListViewController', function () {
                 "creatorName": null
             },
             "serviceType": null,
-            "provider": null,
             "location": null,
             "startDateTime": 1503891000000,
             "endDateTime": 1503900900000,
@@ -297,7 +294,6 @@ describe('AppointmentsListViewController', function () {
                 "creatorName": null
             },
             "serviceType": null,
-            "provider": null,
             "location": null,
             "startDateTime": 1503887400000,
             "endDateTime": 1503889200000,
@@ -327,7 +323,7 @@ describe('AppointmentsListViewController', function () {
                 "creatorName": null
             },
             "serviceType": null,
-            "provider": {"name": "Super Man", "uuid": "c1c26908-3f10-11e4-adec-0800271c1b75"},
+            "providers": [{"name": "Super Man", "uuid": "c1c26908-3f10-11e4-adec-0800271c1b75", "response": "ACCEPTED"}],
             "location": null,
             "startDateTime": 1503923400000,
             "endDateTime": 1503925200000,
@@ -379,7 +375,6 @@ describe('AppointmentsListViewController', function () {
                     "creatorName": null
                 },
                 "serviceType": null,
-                "provider": null,
                 "location": null,
                 "startDateTime": 1503891000000,
                 "endDateTime": 1503900900000,
@@ -409,7 +404,6 @@ describe('AppointmentsListViewController', function () {
                     "creatorName": null
                 },
                 "serviceType": null,
-                "provider": null,
                 "location": null,
                 "startDateTime": 1503887400000,
                 "endDateTime": 1503889200000,
@@ -439,7 +433,7 @@ describe('AppointmentsListViewController', function () {
                     "creatorName": null
                 },
                 "serviceType": null,
-                "provider": {"name": "Super Man", "uuid": "c1c26908-3f10-11e4-adec-0800271c1b75"},
+                "providers": [{"name": "Super Man", "uuid": "c1c26908-3f10-11e4-adec-0800271c1b75", "response": "ACCEPTED"}],
                 "location": null,
                 "startDateTime": 1503923400000,
                 "endDateTime": 1503925200000,
@@ -477,7 +471,7 @@ describe('AppointmentsListViewController', function () {
                 comments: "comment2",
                 status: "Scheduled",
                 appointmentKind: "Scheduled",
-                provider: {name: "provider2"},
+                providers: [{"name": "provider2", "uuid": "c1c26908-3f10-11e4-adec-0800271c1b75", "response": "ACCEPTED"}],
                 endDateTime: 200000,
                 startDateTime: 300000,
                 service: {
@@ -496,7 +490,7 @@ describe('AppointmentsListViewController', function () {
                 comments: "comment1",
                 status: "Completed",
                 appointmentKind: "Completed",
-                provider: {name: "provider1"},
+                providers: [{"name": "provider1", "uuid": "c1c26908-3f10-11e4-adec-0800271c1b76", "response": "ACCEPTED"}],
                 endDateTime: 100000,
                 startDateTime: 200000,
                 service: {
@@ -553,8 +547,8 @@ describe('AppointmentsListViewController', function () {
             scope.sortAppointmentsBy('provider.name');
             expect(scope.sortColumn).toEqual('provider.name');
             expect(scope.filteredAppointments.length).toEqual(2);
-            expect(scope.filteredAppointments[0].provider.name).toEqual("provider1");
-            expect(scope.filteredAppointments[1].provider.name).toEqual("provider2");
+            expect(scope.filteredAppointments[0].providers[0].name).toEqual("provider1");
+            expect(scope.filteredAppointments[1].providers[0].name).toEqual("provider2");
 
             scope.filteredAppointments = [appointment, otherAppointment];
             scope.reverseSort = false;
@@ -617,7 +611,7 @@ describe('AppointmentsListViewController', function () {
                 comments: "comments1",
                 status: "Completed",
                 appointmentKind: "Completed",
-                provider: {name: "provider1"},
+                providers: [{"name": "provider1", "uuid": "c1c26908-3f10-11e4-adec-0800271c1b75", "response": "ACCEPTED"}],
                 endDateTime: 100000,
                 startDateTime: 200000,
                 service: {
@@ -632,7 +626,7 @@ describe('AppointmentsListViewController', function () {
                 comments: "comments2",
                 status: "Scheduled",
                 appointmentKind: "Scheduled",
-                provider: {name: "provider2"},
+                providers: [{"name": "provider2", "uuid": "c1c26908-3f10-11e4-adec-0800271c1b76", "response": "ACCEPTED"}],
                 endDateTime: 200000,
                 startDateTime: 300000,
                 service: {
@@ -673,7 +667,7 @@ describe('AppointmentsListViewController', function () {
                 comments: "comments2",
                 status: "Scheduled",
                 appointmentKind: "Scheduled",
-                provider: {name: "provider2"},
+                providers: [{"name": "provider2", "uuid": "c1c26908-3f10-11e4-adec-0800271c1b76", "response": "ACCEPTED"}],
                 startDateTime: 16007753800000,
                 service: {
                     name: "service2",
@@ -687,7 +681,7 @@ describe('AppointmentsListViewController', function () {
                 comments: "comments1",
                 status: "Completed",
                 appointmentKind: "Completed",
-                provider: {name: "provider1"},
+                providers: [{"name": "provider1", "uuid": "c1c26908-3f10-11e4-adec-0800271c1b75", "response": "ACCEPTED"}],
                 startDateTime: 1508322600000,
                 service: {
                     name: "service1",
@@ -779,7 +773,6 @@ describe('AppointmentsListViewController', function () {
                 "creatorName": null
             },
             "serviceType": null,
-            "provider": null,
             "location": null,
             "startDateTime": 1503891000000,
             "endDateTime": 1503900900000,


### PR DESCRIPTION
Fixed - If a provider is removed from an appointment, it still shows up on the views.
Fixed - not sortable by provider column in list view. now sorts only by the first provider of the appointment, hence will work as long as there is one provider for the appointment.
Also added constants. also fixed issue of wrong provider response getting recorded in certain flows of multiple provider assignment.