### PR TITLE
Fix camera issue with latest version of chrome

### DIFF
--- a/ui/app/common/photo-capture/directives/capturePhoto.js
+++ b/ui/app/common/photo-capture/directives/capturePhoto.js
@@ -72,7 +72,7 @@ angular.module('bahmni.common.photoCapture')
                     navigator.getUserMedia(
                         {video: true, audio: false},
                         function (localMediaStream) {
-                            captureVideo.src = $window.URL.createObjectURL(localMediaStream);
+                            captureVideo.srcObject = localMediaStream;
                             captureActiveStream = localMediaStream;
                             captureDialogElement.dialog('open');
                         },

--- a/ui/app/common/photo-capture/directives/capturePhoto.js
+++ b/ui/app/common/photo-capture/directives/capturePhoto.js
@@ -68,11 +68,21 @@ angular.module('bahmni.common.photoCapture')
                 }
                 dialogOpen = true;
                 navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia;
-                if (navigator.getUserMedia) {
+                if (navigator.mediaDevices) {
+                    navigator.mediaDevices.getUserMedia({video: true, audio: false})
+                    .then(function (localMediaStream) {
+                          captureVideo.srcObject = localMediaStream;
+                          captureActiveStream = localMediaStream;
+                          captureDialogElement.dialog('open');
+                      }).catch(function (e) { 
+                        alert("Could not get access to web camera. Please allow access to web camera");
+                      });
+                }
+                else if (navigator.getUserMedia) {
                     navigator.getUserMedia(
                         {video: true, audio: false},
                         function (localMediaStream) {
-                            captureVideo.srcObject = localMediaStream;
+                            captureVideo.src = $window.URL.createObjectURL(localMediaStream);
                             captureActiveStream = localMediaStream;
                             captureDialogElement.dialog('open');
                         },


### PR DESCRIPTION
URL.createObjectURL() which we used to access the webcam
was deprecated in Chrome versions
prior to Chrome 71. In Chrome 71, this method was removed
and as a result a JavaScript error was thrown everytime you
try to access the Camera.

Resolves: #738