### PR TITLE
Patient Document Module dialog css fix

### DIFF
--- a/ui/app/common/gallery/directives/galleryPane.js
+++ b/ui/app/common/gallery/directives/galleryPane.js
@@ -133,7 +133,7 @@ angular.module('bahmni.common.gallery')
                             });
                         });
                     }
-                    ngDialog.openConfirm({template: '../common/gallery/views/gallery.html', scope: $scope, closeByEscape: true, className: 'ngdialog-theme-default gallery-dialog'});
+                    ngDialog.openConfirm({template: '../common/gallery/views/gallery.html', scope: $scope, closeByEscape: true, className: 'gallery-dialog ngdialog-theme-default'});
                 };
 
                 var fetchObsRelationship = function (image) {

--- a/ui/app/common/gallery/directives/galleryPane.js
+++ b/ui/app/common/gallery/directives/galleryPane.js
@@ -133,7 +133,7 @@ angular.module('bahmni.common.gallery')
                             });
                         });
                     }
-                    ngDialog.openConfirm({template: '../common/gallery/views/gallery.html', scope: $scope, closeByEscape: true});
+                    ngDialog.openConfirm({template: '../common/gallery/views/gallery.html', scope: $scope, closeByEscape: true, className: 'ngdialog-theme-default gallery-dialog'});
                 };
 
                 var fetchObsRelationship = function (image) {

--- a/ui/app/styles/bahmni-components/_gallery.scss
+++ b/ui/app/styles/bahmni-components/_gallery.scss
@@ -289,7 +289,7 @@
   }
 }
 
-.ngdialog.ngdialog-theme-default {
+.gallery-dialog.ngdialog.ngdialog-theme-default {
   padding: 0;
   .ngdialog-content {
     background: #fff;


### PR DESCRIPTION
Overridden by default mg-dialog css, fixing by adding a specific class to the dialog.