### PR TITLE
BAH-790 Functionality to view obs forms based on provider Types

### DIFF
--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -19,7 +19,7 @@ angular.module('bahmni.clinical')
             if (enableProviderTypeBasedFormsAccess) {
                 providerTypeBasedFormsAccess = appService.getAppDescriptor().getConfigValue('providerTypeBasedFormsAccess');
             }
-            
+
             var finalFormsToDisplay;
             var numberOfLevels = 2;
             var fields = ['uuid', 'name:(name,display)', 'names:(uuid,conceptNameType,name)'];
@@ -35,13 +35,13 @@ angular.module('bahmni.clinical')
                         v: "custom:" + customRepresentation
                     }), enableProviderTypeBasedFormsAccess ? providerService.getProviderAttributes(currentProvider.uuid) : null]).then(function (response) {
                         var allTemplates = response[0].data.results[0].setMembers;
-                        
+
                         if (response[1]) {
                             if (response[1].data) {
                                 providerAttributes = response[1].data.results;
                             }
                         }
-                        
+
                         createConceptSections(allTemplates, providerAttributes, providerTypeBasedFormsAccess);
                         if ($state.params.programUuid) {
                             showOnlyTemplatesFilledInProgram();
@@ -179,7 +179,7 @@ angular.module('bahmni.clinical')
                         }
                     }));
                 }
-                
+
                 _.map(allTemplates, function (template) {
                     var conceptSetExtension = _.find(extensions, function (extension) {
                         return extension.extensionParams.conceptName === template.name.name;

--- a/ui/app/clinical/index.html
+++ b/ui/app/clinical/index.html
@@ -141,6 +141,7 @@
         <script src="../common/domain/services/bedService.js"></script>
 
         <script src="../common/domain/services/providerService.js"></script>
+        <script src="../common/domain/services/providerTypeService.js"></script>
 
         <script src="../common/domain/helpers/domainHelpers.js"></script>
         <script src="../common/domain/mappers/providerMapper.js"></script>

--- a/ui/app/common/domain/services/providerService.js
+++ b/ui/app/common/domain/services/providerService.js
@@ -28,9 +28,18 @@ angular.module('bahmni.common.domain')
             });
         };
 
+        var getProviderAttributes = function (providerUuid) {
+            var url = Bahmni.Common.Constants.providerUrl + "/" + providerUuid + "/attribute";
+            return $http.get(url, {
+                method: "GET",
+                cache: false
+            });
+        };
+
         return {
             search: search,
             searchByUuid: searchByUuid,
-            list: list
+            list: list,
+            getProviderAttributes: getProviderAttributes
         };
     }]);

--- a/ui/app/common/domain/services/providerTypeService.js
+++ b/ui/app/common/domain/services/providerTypeService.js
@@ -4,12 +4,12 @@ angular.module('bahmni.common.domain')
     .factory('providerTypeService', ['$http', 'providerService', function ($http, providerService) {
         var getProviderType = function (providerAttributes, providerTypeBasedFormsAccess) {
             var keys = Object.keys(providerTypeBasedFormsAccess);
-           return _.filter(_.map(providerAttributes, function(providerAttribute) {
+            return _.filter(_.map(providerAttributes, function (providerAttribute) {
                 if (_.includes(keys, providerAttribute.attributeType.display)) {
                     if (providerAttribute.value && providerAttribute.voided === false) {
                         return providerAttribute.attributeType.display;
                     }
-                }    
+                }
             }));
         };
 

--- a/ui/app/common/domain/services/providerTypeService.js
+++ b/ui/app/common/domain/services/providerTypeService.js
@@ -1,0 +1,19 @@
+'use strict';
+
+angular.module('bahmni.common.domain')
+    .factory('providerTypeService', ['$http', 'providerService', function ($http, providerService) {
+        var getProviderType = function (providerAttributes, providerTypeBasedFormsAccess) {
+            var keys = Object.keys(providerTypeBasedFormsAccess);
+           return _.filter(_.map(providerAttributes, function(providerAttribute) {
+                if (_.includes(keys, providerAttribute.attributeType.display)) {
+                    if (providerAttribute.value && providerAttribute.voided === false) {
+                        return providerAttribute.attributeType.display;
+                    }
+                }    
+            }));
+        };
+
+        return {
+            getProviderType: getProviderType
+        };
+    }]);

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 describe('ConceptSetPageController', function () {
-    var scope, controller, rootScope, conceptSetService, configurations, clinicalAppConfigService, state, encounterConfig, spinner, messagingService, translate, stateParams, formService;
+    var scope, controller, rootScope, conceptSetService, configurations, clinicalAppConfigService, state, encounterConfig, spinner, messagingService, translate, stateParams, formService, appService, appDescriptor;
     stateParams = {conceptSetGroupName: "concept set group name"};
     var extension = {"extension": {
         extensionParams: {}
@@ -46,11 +46,15 @@ describe('ConceptSetPageController', function () {
                 "allowAddMore": true
             }
         };
+        rootScope.currentProvider = {uuid:'212332-233322'};
         clinicalAppConfigService.getAllConceptsConfig.and.returnValue(configs);
         configurations = jasmine.createSpyObj("configurations", ["encounterConfig"]);
         configurations.encounterConfig.and.returnValue(encounterConfig);
         conceptSetService = jasmine.createSpyObj("conceptSetService", ["getConcept", "getObsTemplatesForProgram"]);
         formService = jasmine.createSpyObj("formService", ["getFormList"]);
+        appService = jasmine.createSpyObj("appService", ["getAppDescriptor"]);
+        appDescriptor = jasmine.createSpyObj('appDescriptor', ['getConfigValue']);
+        appService.getAppDescriptor.and.returnValue(appDescriptor);
         spinner = jasmine.createSpyObj("spinner", ["forPromise"]);
         messagingService = jasmine.createSpyObj('messagingService', ['showMessage']);
         translate = jasmine.createSpyObj('$translate',['instant']);
@@ -66,6 +70,7 @@ describe('ConceptSetPageController', function () {
             $stateParams: stateParams,
             conceptSetService: conceptSetService,
             formService: formService,
+            appService: appService,
             clinicalAppConfigService: clinicalAppConfigService,
             messagingService: messagingService,
             configurations: configurations,

--- a/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
+++ b/ui/test/unit/clinical/consultation/controllers/conceptSetPageController.spec.js
@@ -125,7 +125,7 @@ describe('ConceptSetPageController', function () {
                 }
             };
             createController();
-
+            scope.$apply();
             expect(scope.allTemplates).toBeTruthy();
             expect(scope.allTemplates.length).toEqual(1);
             expect(scope.allTemplates[0].conceptName).toEqual("abcd");
@@ -156,7 +156,7 @@ describe('ConceptSetPageController', function () {
                 }
             };
             createController();
-
+            scope.$apply();
             expect(scope.allTemplates).toBeTruthy();
             expect(scope.allTemplates.length).toEqual(2);
             expect(scope.allTemplates[0].conceptName).toEqual("abcd");
@@ -183,7 +183,7 @@ describe('ConceptSetPageController', function () {
             mockConceptSetService(conceptResponseData);
             mockformService(data);
             createController();
-
+            scope.$apply();
             expect(scope.allTemplates).toBeTruthy();
             expect(scope.allTemplates.length).toEqual(2);
             expect(scope.allTemplates[0].conceptName).toEqual("abcd");
@@ -213,7 +213,7 @@ describe('ConceptSetPageController', function () {
             }};
 
             createController();
-
+            scope.$apply();
             expect(scope.allTemplates).toBeTruthy();
             expect(scope.allTemplates.length).toEqual(1);
             expect(scope.allTemplates[0].conceptName).toEqual("abcd");
@@ -265,7 +265,7 @@ describe('ConceptSetPageController', function () {
                 uuid: "random-uuid"
             }];
             createController();
-
+            scope.$apply();
             expect(scope.allTemplates).toBeTruthy();
             expect(scope.allTemplates.length).toEqual(3);
 
@@ -304,7 +304,7 @@ describe('ConceptSetPageController', function () {
                 }
             };
             createController();
-
+            scope.$apply();
             expect(scope.allTemplates).toBeTruthy();
             expect(scope.allTemplates.length).toEqual(2);
 
@@ -352,7 +352,7 @@ describe('ConceptSetPageController', function () {
             };
 
             createController();
-
+            scope.$apply();
             expect(scope.allTemplates.length).toEqual(4);
             expect(scope.consultation.selectedObsTemplate.length).toEqual(2);
 
@@ -422,7 +422,7 @@ describe('ConceptSetPageController', function () {
             scope.consultation.lastvisited = 'concept-set-123';
 
             createController();
-
+            scope.$apply();
             expect(scope.consultation.observations.length).toBe(2);
             expect(scope.consultation.selectedObsTemplate[0].label).toBe("Followup Assessment");
             expect(scope.consultation.selectedObsTemplate[1].label).toBe("Baseline");


### PR DESCRIPTION
To test this functionality this PR is also needed: https://github.com/Bahmni/default-config/pull/38
This functionality depends on 2 configs mentioned in the above PR.

The first one is `enableProviderTypeBasedFormsAccess` which is set to false by default. When its set to false, the regular functionality/workflow takes place i.e. All the Obs Forms are visible to the current provider.

If it is set to true , the Provider Type Based access to forms is enabled i.e. a particular provider is only able to view the Obs forms assigned to them.

In the linked PR , there are 2 provider types: provider1 & provider2 and each have a particular set of forms that they can view.

For this to actually work, providerAttribute types have to be created in OpenMRS with the exact same names as the ones specified in the app.json file. The attribute datatype must be boolean.

Create multiple attributes as per your requirements. Then set the value of the attributes to true for your providers. For example, your Provider is called "Dr.John" who is of type "XYZ" then set the XYZ provider attribute for Dr.John to true.

This will ensure that Dr. John of type XYZ can only view the forms mentioned in the app.json config