### PR TITLE
feat: Remove unsupported banner for Firefox

### DIFF
--- a/ui/app/home/controllers/loginController.js
+++ b/ui/app/home/controllers/loginController.js
@@ -71,8 +71,18 @@ angular.module('bahmni.home')
                 });
             });
 
+            var supportedBrowsers = ["Firefox", "Chrome"];
+            $scope.isSupportedBrowser = function () {
+                for (var i = 0; i < supportedBrowsers.length; i++) {
+                    if ($window.navigator.userAgent.indexOf(supportedBrowsers[i]) !== -1) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+
             $scope.isChrome = function () {
-                if ($window.navigator.userAgent.indexOf("Chrome") != -1) {
+                if ($window.navigator.userAgent.indexOf("Chrome") !== -1) {
                     return true;
                 }
                 return false;

--- a/ui/app/home/views/login.html
+++ b/ui/app/home/views/login.html
@@ -18,7 +18,7 @@
     <form ng-submit="login()" name="loginForm" bm-form autofillable="true">
         <div class="login-body">
             <div class="note-container">
-                <div class="note error" ng-if="!isChrome()">
+                <div class="note error" ng-if="!isSupportedBrowser()">
                     <div class="text">
                     {{ 'LOGIN_UNSUPPORTED_BROWSER_KEY'  | translate }}
                     </div>


### PR DESCRIPTION
Bahmni seems to show a banner that only Chrome is supported. While almost all the browsers should be compatible, at least Firefox is not uncompatible with any of the functionalities used in Bahmni. So I've taken the liberty of removing that banner for Firefox. I guess this should be extended to include at least Safari and other Chromium based browsers.

Nevertheless, I've just started diving in the code so feel free to correct me about any specific functionality that is only available to Chrome that makes this PR useless.

Thanks in advance.