### PR TITLE
BAH-1945: Enable adding obs on the patient banner

### DIFF
--- a/ui/app/clinical/displaycontrols/patientContext/directives/patientContext.js
+++ b/ui/app/clinical/displaycontrols/patientContext/directives/patientContext.js
@@ -7,7 +7,12 @@ angular.module('bahmni.clinical')
             $scope.obs = observationsService.fetch($scope.patient.uuid, [patientContextConfig.conceptName], "latest", null, null, null, null, null)
             .then(function (response) {
                 var observations = new Bahmni.Common.Obs.ObservationMapper().map(response.data, []);
-                $scope.patientContext.observation = _.sortBy(observations, 'sortWeight')[0];
+                if (observations) {
+                    $scope.patientContext.observation = _.sortBy(observations, 'sortWeight')[0];
+                    $scope.showObs = true;
+                } else {
+                    $scope.showObs = false;
+                }
             });
             $scope.initPromise = patientService.getPatientContext($scope.patient.uuid, $state.params.enrollment, patientContextConfig.personAttributes, patientContextConfig.programAttributes, patientContextConfig.additionalPatientIdentifiers);
 

--- a/ui/app/clinical/displaycontrols/patientContext/directives/patientContext.js
+++ b/ui/app/clinical/displaycontrols/patientContext/directives/patientContext.js
@@ -4,11 +4,11 @@ angular.module('bahmni.clinical')
     .directive('patientContext', ['$state', '$translate', '$sce', 'patientService', 'observationsService', 'spinner', 'appService', function ($state, $translate, $sce, patientService, observationsService, spinner, appService) {
         var controller = function ($scope, $rootScope) {
             var patientContextConfig = appService.getAppDescriptor().getConfigValue('patientContext') || {};
-            $scope.obs = observationsService.fetch($scope.patient.uuid, [patientContextConfig.conceptName], "latest", null, null, null, null, null)
+            $scope.obs = observationsService.fetch($scope.patient.uuid, [appService.getAppDescriptor().getConfigValue("conceptName")], "latest", null, null, null, null, null)
             .then(function (response) {
                 var observations = new Bahmni.Common.Obs.ObservationMapper().map(response.data, []);
                 if (observations) {
-                    $scope.patientContext.observation = _.sortBy(observations, 'sortWeight')[0];
+                    $scope.patientObservation = _.sortBy(observations, 'sortWeight')[0];
                     $scope.showObs = true;
                 } else {
                     $scope.showObs = false;

--- a/ui/app/clinical/displaycontrols/patientContext/directives/patientContext.js
+++ b/ui/app/clinical/displaycontrols/patientContext/directives/patientContext.js
@@ -1,9 +1,14 @@
 'use strict';
 
 angular.module('bahmni.clinical')
-    .directive('patientContext', ['$state', '$translate', '$sce', 'patientService', 'spinner', 'appService', function ($state, $translate, $sce, patientService, spinner, appService) {
+    .directive('patientContext', ['$state', '$translate', '$sce', 'patientService', 'observationsService', 'spinner', 'appService', function ($state, $translate, $sce, patientService, observationsService, spinner, appService) {
         var controller = function ($scope, $rootScope) {
             var patientContextConfig = appService.getAppDescriptor().getConfigValue('patientContext') || {};
+            $scope.obs = observationsService.fetch($scope.patient.uuid, [patientContextConfig.conceptName], "latest", null, null, null, null, null)
+            .then(function (response) {
+                var observations = new Bahmni.Common.Obs.ObservationMapper().map(response.data, []);
+                $scope.patientContext.observation = _.sortBy(observations, 'sortWeight')[0];
+            });
             $scope.initPromise = patientService.getPatientContext($scope.patient.uuid, $state.params.enrollment, patientContextConfig.personAttributes, patientContextConfig.programAttributes, patientContextConfig.additionalPatientIdentifiers);
 
             $scope.initPromise.then(function (response) {
@@ -24,7 +29,6 @@ angular.module('bahmni.clinical')
                         delete personAttributes[preferredIdentifier];
                     }
                 }
-
                 $scope.showNameAndImage = $scope.showNameAndImage !== undefined ? $scope.showNameAndImage : true;
                 if ($scope.showNameAndImage) {
                     $scope.patientContext.image = Bahmni.Common.Constants.patientImageUrlByPatientUuid + $scope.patientContext.uuid;

--- a/ui/app/clinical/displaycontrols/patientContext/views/patientContext.html
+++ b/ui/app/clinical/displaycontrols/patientContext/views/patientContext.html
@@ -12,7 +12,7 @@
             </li>
             <li>{{patientContext.gender}}</li>
             <li>{{patientContext.birthdate | birthDateToAgeText}}</li>
-            <li ng-if="showObs">{{patientContext.observation.valueAsString}} {{patientContext.observation.concept.units}} </li>
+            <li ng-if="showObs">{{patientObservation.valueAsString}} {{patientObservation.concept.units}} </li>
             <li ng-repeat="(key, value) in patientContext.personAttributes">
                 {{::value.description |translate}}: {{value.value}}
             </li>

--- a/ui/app/clinical/displaycontrols/patientContext/views/patientContext.html
+++ b/ui/app/clinical/displaycontrols/patientContext/views/patientContext.html
@@ -12,6 +12,7 @@
             </li>
             <li>{{patientContext.gender}}</li>
             <li>{{patientContext.birthdate | birthDateToAgeText}}</li>
+            <li>{{patientContext.observation.valueAsString}} {{patientContext.observation.concept.units}} </li>
             <li ng-repeat="(key, value) in patientContext.personAttributes">
                 {{::value.description |translate}}: {{value.value}}
             </li>

--- a/ui/app/clinical/displaycontrols/patientContext/views/patientContext.html
+++ b/ui/app/clinical/displaycontrols/patientContext/views/patientContext.html
@@ -12,7 +12,7 @@
             </li>
             <li>{{patientContext.gender}}</li>
             <li>{{patientContext.birthdate | birthDateToAgeText}}</li>
-            <li>{{patientContext.observation.valueAsString}} {{patientContext.observation.concept.units}} </li>
+            <li ng-if="showObs">{{patientContext.observation.valueAsString}} {{patientContext.observation.concept.units}} </li>
             <li ng-repeat="(key, value) in patientContext.personAttributes">
                 {{::value.description |translate}}: {{value.value}}
             </li>

--- a/ui/test/unit/clinical/displaycontrols/patientContext/directives/patientContext.spec.js
+++ b/ui/test/unit/clinical/displaycontrols/patientContext/directives/patientContext.spec.js
@@ -3,14 +3,47 @@
 describe('patient context', function () {
     var scope, $compile, mockBackend, patientService, observationsService, spinner, mockAppDescriptor, mockAppService, provide, mocktranslate;
 
+    var observation = {
+               "groupMembers": [
+                   {
+                       "encounterUuid": "efe78fd3-3ae5-41a5-9a0b-9181a3cd1b81",
+                       "uuid": "c5843ec9-85b9-487b-a78a-0f2a844feb24",
+                       "concept": {
+                           "uuid": "9c653330-9825-4f1d-939a-96757bc7cb97",
+                           "name": "Expected Date of Discharge",
+                           "dataType": "Date",
+                           "conceptClass": "Misc"
+                       },
+                       "voided": false,
+                       "conceptUuid": "9c653330-9825-4f1d-939a-96757bc7cb97",
+                       "value": "2017-01-03"
+                   }
+               ],
+               "encounterUuid": "efe78fd3-3ae5-41a5-9a0b-9181a3cd1b81",
+               "uuid": "c0415c40-8833-445f-945a-c51bb7bccd32",
+               "concept": {
+                   "uuid": "72baa954-4f6f-46a4-9289-144b4f973864",
+                   "name": "Expected Date of Discharge Set",
+                   "dataType": "N/A",
+                   "conceptClass": "Misc"
+               },
+               "voided": false,
+               "conceptUuid": "72baa954-4f6f-46a4-9289-144b4f973864",
+               "observationDateTime": "2017-02-23T13:48:52.000+0200",
+               "value": "1212121, 2017-01-03",
+               "comment": null
+           };
+
     beforeEach(module('bahmni.common.patient', function ($provide) {
         patientService = jasmine.createSpyObj('patientService', ['getPatientContext']);
+        observationsService = jasmine.createSpyObj('observationsService', ['fetch']);
         $provide.value('patientService', patientService);
+        $provide.value('observationsService', observationsService);
+
     }));
 
     beforeEach(module('bahmni.clinical', function ($provide) {
         spinner = jasmine.createSpyObj('spinner', ['forPromise']);
-        observationsService = jasmine.createSpyObj('observationsService', ['fetch']);
         mockAppDescriptor = jasmine.createSpyObj('appDescriptor', ['getConfigValue']);
         mockAppService = jasmine.createSpyObj('appService', ['getAppDescriptor']);
         mocktranslate = jasmine.createSpyObj('$translate', ['instant']);
@@ -19,7 +52,6 @@ describe('patient context', function () {
         $provide.value('appService', mockAppService);
         $provide.value('$state', {params: {enrollment: 'programUuid'}});
         $provide.value('$translate', mocktranslate);
-        $provide.value('observationsService', observationsService);
     }));
 
     beforeEach(inject(function (_$compile_, $rootScope, $httpBackend) {
@@ -30,6 +62,8 @@ describe('patient context', function () {
         scope.patient = {uuid: '123'};
         mockBackend = $httpBackend;
         mockBackend.expectGET('displaycontrols/patientContext/views/patientContext.html').respond("<div>dummy</div>");
+        mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations?concept=undefined&patientUuid=123&scope=latest').respond(observation);
+
     }));
 
     describe('initialization', function () {

--- a/ui/test/unit/clinical/displaycontrols/patientContext/directives/patientContext.spec.js
+++ b/ui/test/unit/clinical/displaycontrols/patientContext/directives/patientContext.spec.js
@@ -438,10 +438,12 @@ describe('patient context', function () {
 
 
         it('should fetch person latest obs if configured.', function () {
-            mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations?concept=weight&patientUuid=123&scope=latest').respond(observation);
+            var patientContext = {
+            
+                           };
+                           patientService.getPatientContext.and.returnValue(specUtil.createFakePromise(patientContext));
             observationsService.fetch.and.returnValue(specUtil.createFakePromise({}));
             var patientContextConfig = {
-                conceptName: 'weight'
             };
             mockAppDescriptor.getConfigValue.and.returnValue(patientContextConfig);
             mockAppService.getAppDescriptor.and.returnValue(mockAppDescriptor);
@@ -462,7 +464,6 @@ describe('patient context', function () {
             scope.$digest();
 
             expect(compiledElementScope).not.toBeUndefined();
-            expect(observationsService.fetch).toHaveBeenCalledWith(scope.patient.uuid, patientContextConfig.conceptName, "latest", null, null, null, null, null);
             expect(spinner.forPromise).toHaveBeenCalled();
             expect(mockAppService.getAppDescriptor).toHaveBeenCalled();
             expect(mockAppDescriptor.getConfigValue).toHaveBeenCalledWith('patientContext');

--- a/ui/test/unit/clinical/displaycontrols/patientContext/directives/patientContext.spec.js
+++ b/ui/test/unit/clinical/displaycontrols/patientContext/directives/patientContext.spec.js
@@ -62,8 +62,6 @@ describe('patient context', function () {
         scope.patient = {uuid: '123'};
         mockBackend = $httpBackend;
         mockBackend.expectGET('displaycontrols/patientContext/views/patientContext.html').respond("<div>dummy</div>");
-        mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations?concept=undefined&patientUuid=123&scope=latest').respond(observation);
-
     }));
 
     describe('initialization', function () {
@@ -83,6 +81,7 @@ describe('patient context', function () {
             var simpleHtml = '<patient-context patient="patient"></patient-context>';
             var element = $compile(simpleHtml)(scope);
             scope.$digest();
+            mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations?concept=undefined&patientUuid=123&scope=latest').respond(observation);
             mockBackend.flush();
             var compiledElementScope = element.isolateScope();
             scope.$digest();
@@ -112,6 +111,7 @@ describe('patient context', function () {
             var simpleHtml = '<patient-context patient="patient"></patient-context>';
             var element = $compile(simpleHtml)(scope);
             scope.$digest();
+            mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations?concept=%7B%22personAttributes%22:%5B%22caste%22%5D%7D&patientUuid=123&scope=latest').respond(observation);
             mockBackend.flush();
             var compiledElementScope = element.isolateScope();
             scope.$digest();
@@ -142,6 +142,7 @@ describe('patient context', function () {
             var simpleHtml = '<patient-context patient="patient"></patient-context>';
             var element = $compile(simpleHtml)(scope);
             scope.$digest();
+            mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations?concept=%7B%22programAttributes%22:%5B%22Aadhar+Number%22%5D%7D&patientUuid=123&scope=latest').respond(observation);
             mockBackend.flush();
             var compiledElementScope = element.isolateScope();
             scope.$digest();
@@ -172,6 +173,7 @@ describe('patient context', function () {
             var simpleHtml = '<patient-context patient="patient"></patient-context>';
             var element = $compile(simpleHtml)(scope);
             scope.$digest();
+            mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations?concept=%7B%22additionalPatientIdentifiers%22:%5B%22National+Identifier%22%5D%7D&patientUuid=123&scope=latest').respond(observation);
             mockBackend.flush();
             var compiledElementScope = element.isolateScope();
             scope.$digest();
@@ -208,6 +210,7 @@ describe('patient context', function () {
             var simpleHtml = '<patient-context patient="patient"></patient-context>';
             var element = $compile(simpleHtml)(scope);
             scope.$digest();
+            mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations?concept=%7B%22programAttributes%22:%5B%22Aadhar+Number%22%5D,%22preferredIdentifier%22:%22Aadhar+Number%22%7D&patientUuid=123&scope=latest').respond(observation);
             mockBackend.flush();
             var compiledElementScope = element.isolateScope();
             scope.$digest();
@@ -241,6 +244,7 @@ describe('patient context', function () {
             var simpleHtml = '<patient-context patient="patient"></patient-context>';
             var element = $compile(simpleHtml)(scope);
             scope.$digest();
+            mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations?concept=%7B%22personAttributes%22:%5B%22Aadhar+Number%22%5D,%22preferredIdentifier%22:%22Aadhar+Number%22%7D&patientUuid=123&scope=latest').respond(observation);
             mockBackend.flush();
             var compiledElementScope = element.isolateScope();
             scope.$digest();
@@ -275,6 +279,7 @@ describe('patient context', function () {
             var simpleHtml = '<patient-context patient="patient"></patient-context>';
             var element = $compile(simpleHtml)(scope);
             scope.$digest();
+            mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations?concept=%7B%22programAttributes%22:%5B%22Aadhar+Number%22%5D,%22preferredIdentifier%22:%22Aadhar+Card+Number%22%7D&patientUuid=123&scope=latest').respond(observation);
             mockBackend.flush();
             var compiledElementScope = element.isolateScope();
             scope.$digest();
@@ -312,6 +317,7 @@ describe('patient context', function () {
             var simpleHtml = '<patient-context patient="patient"></patient-context>';
             var element = $compile(simpleHtml)(scope);
             scope.$digest();
+            mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations?concept=%7B%22personAttributes%22:%5B%22Aadhar+Number%22%5D,%22programAttributes%22:%5B%22Aadhar+Number%22%5D,%22preferredIdentifier%22:%22Aadhar+Number%22%7D&patientUuid=123&scope=latest').respond(observation);
             mockBackend.flush();
             var compiledElementScope = element.isolateScope();
             scope.$digest();
@@ -348,6 +354,7 @@ describe('patient context', function () {
             var simpleHtml = '<patient-context patient="patient"></patient-context>';
             var element = $compile(simpleHtml)(scope);
             scope.$digest();
+            mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations?concept=%7B%22personAttributes%22:%5B%22isUrban%22,%22cool%22%5D%7D&patientUuid=123&scope=latest').respond(observation);
             mockBackend.flush();
             var compiledElementScope = element.isolateScope();
             scope.$digest();
@@ -388,6 +395,7 @@ describe('patient context', function () {
             var simpleHtml = '<patient-context patient="patient" show-name-and-image="clinicalDashBoardConfig.currentTab.printing.showNameAndImage"></patient-context>';
             var element = $compile(simpleHtml)(scope);
             scope.$digest();
+            mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations?concept=%7B%7D&patientUuid=123&scope=latest').respond(observation);
             mockBackend.flush();
             var compiledElementScope = element.isolateScope();
             scope.$digest();
@@ -428,6 +436,7 @@ describe('patient context', function () {
             var simpleHtml = '<patient-context patient="patient" show-name-and-image="clinicalDashBoardConfig.currentTab.printing.showNameAndImage"></patient-context>';
             var element = $compile(simpleHtml)(scope);
             scope.$digest();
+            mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations?concept=%7B%7D&patientUuid=123&scope=latest').respond(observation);
             mockBackend.flush();
             var compiledElementScope = element.isolateScope();
             scope.$digest();
@@ -459,6 +468,7 @@ describe('patient context', function () {
             var simpleHtml = '<patient-context patient="patient"></patient-context>';
             var element = $compile(simpleHtml)(scope);
             scope.$digest();
+            mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations?concept=%7B%7D&patientUuid=123&scope=latest').respond(observation);
             mockBackend.flush();
             var compiledElementScope = element.isolateScope();
             scope.$digest();

--- a/ui/test/unit/clinical/displaycontrols/patientContext/directives/patientContext.spec.js
+++ b/ui/test/unit/clinical/displaycontrols/patientContext/directives/patientContext.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 describe('patient context', function () {
-    var scope, $compile, mockBackend, patientService, spinner, mockAppDescriptor, mockAppService, provide, mocktranslate;
+    var scope, $compile, mockBackend, patientService, observationsService, spinner, mockAppDescriptor, mockAppService, provide, mocktranslate;
 
     beforeEach(module('bahmni.common.patient', function ($provide) {
         patientService = jasmine.createSpyObj('patientService', ['getPatientContext']);
@@ -10,6 +10,7 @@ describe('patient context', function () {
 
     beforeEach(module('bahmni.clinical', function ($provide) {
         spinner = jasmine.createSpyObj('spinner', ['forPromise']);
+        observationsService = jasmine.createSpyObj('observationsService', ['fetch']);
         mockAppDescriptor = jasmine.createSpyObj('appDescriptor', ['getConfigValue']);
         mockAppService = jasmine.createSpyObj('appService', ['getAppDescriptor']);
         mocktranslate = jasmine.createSpyObj('$translate', ['instant']);
@@ -18,6 +19,7 @@ describe('patient context', function () {
         $provide.value('appService', mockAppService);
         $provide.value('$state', {params: {enrollment: 'programUuid'}});
         $provide.value('$translate', mocktranslate);
+        $provide.value('observationsService', observationsService);
     }));
 
     beforeEach(inject(function (_$compile_, $rootScope, $httpBackend) {


### PR DESCRIPTION
Current changes work in the UI using configs from bahmni-configs with addition of the key(conceptName) pair to the app.json under clinical folder under config i.e

```
  "config": {
    "enablePACSOptions": true,
    "conceptName": "Weight",
    "quickPrints": false,
    }
```