### PR TITLE
BAH-1983 | Fix. Login redirect when session expired

### DIFF
--- a/ui/app/common/util/httpErrorInterceptor.js
+++ b/ui/app/common/util/httpErrorInterceptor.js
@@ -29,7 +29,7 @@ angular.module('httpErrorInterceptor', [])
 
             function shouldRedirectToLogin (response) {
                 var errorMessage = response.data.error ? response.data.error.message : response.data;
-                if (errorMessage.search("HTTP Status 403 - Session timed out") > 0) {
+                if (errorMessage.search("Session timed out") > 0) {
                     return true;
                 }
             }


### PR DESCRIPTION
When the session is expired with OpenMRS running in docker setup, the error title has `HTTP Status 403 - Forbidden` . This causes the redirect to not happen. But the `Message` attribute in the error page is similar. So validating with it should work on both setup methods.

JIRA -> [BAH-1983](https://bahmni.atlassian.net/browse/BAH-1983)