### PR TITLE
BAH-1734 | Added extension in getting observation form

### DIFF
--- a/ui/app/clinical/consultation/controllers/conceptSetPageController.js
+++ b/ui/app/clinical/consultation/controllers/conceptSetPageController.js
@@ -227,6 +227,9 @@ angular.module('bahmni.clinical')
                 var forms = [];
                 var observations = $scope.consultation.observations || [];
                 _.each(observationsForms, function (observationForm) {
+                    var extension = _.find(extensions, function (ext) {
+                        return (ext.extensionParams.formName && (observationForm.formName === ext.extensionParams.formName || observationForm.name === ext.extensionParams.formName));
+                    }) || {};
                     var formUuid = observationForm.formUuid || observationForm.uuid;
                     var formName = observationForm.name || observationForm.formName;
                     var formVersion = observationForm.version || observationForm.formVersion;
@@ -242,7 +245,7 @@ angular.module('bahmni.clinical')
                     }
                     if ($scope.isFormEditableByTheUser(observationForm)) {
                         var newForm = new Bahmni.ObservationForm(formUuid, $rootScope.currentUser,
-                                                                   formName, formVersion, observations, label);
+                                                                   formName, formVersion, observations, label, extension);
                         newForm.privileges = privileges;
                         forms.push(newForm);
                     }

--- a/ui/app/common/concept-set/models/observationForm.js
+++ b/ui/app/common/concept-set/models/observationForm.js
@@ -89,7 +89,7 @@ Bahmni.ObservationForm = function (formUuid, user, formName, formVersion, observ
     };
 
     self.isDefault = function () {
-        return false;
+        return self.options.default;
     };
 
     Object.defineProperty(self, "isAdded", {


### PR DESCRIPTION
Form 2 forms were not  being picked as default forms under observations tab, made this change to resolve the issue.
Co-authored-by: Kavitha S <kavitha.s@thoughtworks.com>