### PR TITLE
BAH-2805 | Add fix for copy error button

### DIFF
--- a/ui/app/common/ui-helper/controllers/messageController.js
+++ b/ui/app/common/ui-helper/controllers/messageController.js
@@ -10,6 +10,9 @@ angular.module('bahmni.common.uiHelper')
                 $scope.messages[level].forEach(function (message) {
                     string = string.concat(message.value);
                 });
+
+                navigator.clipboard.writeText(string);
+
                 return string;
             };
 

--- a/ui/app/common/ui-helper/messages.html
+++ b/ui/app/common/ui-helper/messages.html
@@ -27,7 +27,7 @@
                         </div>
                     </div>
                     <div class="button-wrappper clearfix">
-                        <button type="button" clip-copy="getMessageText('error')" class="copy-btn fl">{{ 'MESSAGE_DIALOG_OPTION_COPY' | translate }}</button>
+                        <button type="button" ng-click="getMessageText('error')" class="copy-btn fl">{{ 'MESSAGE_DIALOG_OPTION_COPY' | translate }}</button>
                         <button type="button" ng-click="hideMessage('error')" class="show-btn fr">{{ 'MESSAGE_DIALOG_OPTION_OKAY' | translate }}</button>
                     </div>
                 </div>


### PR DESCRIPTION
[BAH-2805](https://bahmni.atlassian.net/browse/BAH-2805) requirement was to fix "Copy Error" button which was not working for any of the pages

Seems to me that **ng-clip** and **zeroclipboard** libraries are not working as expected.

I tried it on a Plunkr 👇 and it doesn’t work there either. 
[ng-clip live example](https://embed.plnkr.co/plunk/tUXevJ)  

This problem can be resolved by leveraging window’s navigator object and copying the error text to the clipboard

I've also updated the `clip-copy` property of message button to `ng-click` since clip-copy is not working as expected.

@binduak @kk-tw @gokultw 