### PR TITLE
BAH-2901 | Fix. Test name when result has uploaded file

### DIFF
--- a/ui/app/clinical/displaycontrols/investigationresults/views/investigationTableRow.html
+++ b/ui/app/clinical/displaycontrols/investigationresults/views/investigationTableRow.html
@@ -6,14 +6,10 @@
     <td class="testUnderPanel" bo-class="{'has-uploaded-file': test.uploadedFileName}">
         <span ng-if="!test.uploadedFileName" bo-text="::getLocaleSpecificNameForTest(test)"></span>
         <span ng-if="test.labReportUrl">
-            <a class="uploaded-file"  href="{{test.labReportUrl}}" stop-event-propagation="click" target="_blank">{{test.preferredNameByLocale}}
-                <span bo-show="test.hasRange" class="range">
-                    <span bo-text="getFormattedRange(test)"></span>
-                </span>
-                 <span bo-show="test.testUnitOfMeasurement" class="range" bo-text="test.testUnitOfMeasurement"></span>
+            <a  href="{{test.labReportUrl}}" stop-event-propagation="click" target="_blank">{{::getLocaleSpecificNameForTest(test)}}
             </a>
         </span>
-        <span bo-show="test.hasRange && !test.uploadedFileName" class="range">
+        <span bo-show="test.hasRange" class="range">
             <span bo-text="getFormattedRange(test)"></span>
         </span>
         <span bo-show="test.testUnitOfMeasurement" class="range" bo-text="test.testUnitOfMeasurement"></span>


### PR DESCRIPTION
This PR fixes the issue with Lab Results display in which test name is not displayed when a file is uploaded along with the lab result. 

- Replaced `test.preferredNameByLocale` with `::getLocaleSpecificNameForTest(test)`
- Removed some duplicates

Before Fix:
<img width="657" alt="Screenshot 2023-03-07 at 9 38 54 AM" src="https://user-images.githubusercontent.com/31698165/223319298-a9cb9224-0311-44b8-b65b-d9457e5dc934.png">


After Fix:
<img width="653" alt="Screenshot 2023-03-07 at 9 37 10 AM" src="https://user-images.githubusercontent.com/31698165/223319342-460b1851-5330-4c9a-b09d-cfdc9f97a8c6.png">
