### PR TITLE
BAH-1784 | Changed create visit Api to a new API

### DIFF
--- a/ui/app/common/constants.js
+++ b/ui/app/common/constants.js
@@ -95,6 +95,7 @@ Bahmni.Common = Bahmni.Common || {};
         bahmniConceptAnswerUrl: RESTWS_V1 + "/bahmniconceptanswer",
         conceptSearchByFullNameUrl: RESTWS_V1 + "/concept?s=byFullySpecifiedName",
         visitUrl: RESTWS_V1 + "/visit",
+        bamniVisitUrl: BAHMNI_CORE + "/visit/startVisit",
         endVisitUrl: BAHMNI_CORE + "/visit/endVisit",
         endVisitAndCreateEncounterUrl: BAHMNI_CORE + "/visit/endVisitAndCreateEncounter",
         visitTypeUrl: RESTWS_V1 + "/visittype",

--- a/ui/app/common/domain/services/visitService.js
+++ b/ui/app/common/domain/services/visitService.js
@@ -32,7 +32,7 @@ angular.module('bahmni.common.domain')
         };
 
         this.createVisit = function (visitDetails) {
-            return $http.post(Bahmni.Common.Constants.visitUrl, visitDetails, {
+            return $http.post(Bahmni.Common.Constants.bamniVisitUrl, visitDetails, {
                 withCredentials: true
             });
         };

--- a/ui/test/unit/common/domain/services/visitService.spec.js
+++ b/ui/test/unit/common/domain/services/visitService.spec.js
@@ -2,6 +2,7 @@
 
 describe('Registration Visit Service', function () {
     var visitService;
+    var bahmniVisitUrl = "/openmrs/ws/rest/v1/bahmnicore/visit/startVisit";
     var openmrsVisitUrl = "/openmrs/ws/rest/v1/visit";
     var endVisitUrl = "/openmrs/ws/rest/v1/endVisit";
     var endVisitAndCreateEncounterUrl = "/openmrs/ws/rest/v1/bahmnicore/visit/endVisitAndCreateEncounter";
@@ -27,7 +28,7 @@ describe('Registration Visit Service', function () {
         module('bahmni.common.domain');
         module(function ($provide) {
             Bahmni.Common.Constants.endVisitUrl = endVisitUrl;
-            Bahmni.Common.Constants.visitUrl = openmrsVisitUrl;
+            Bahmni.Common.Constants.bahmnivisitUrl = bahmniVisitUrl;
             $provide.value('$http', mockHttp);
         });
 
@@ -61,7 +62,7 @@ describe('Registration Visit Service', function () {
         visitService.createVisit(visitDetails);
 
         expect(mockHttp.post).toHaveBeenCalled();
-        expect(mockHttp.post.calls.mostRecent().args[0]).toBe(openmrsVisitUrl);
+        expect(mockHttp.post.calls.mostRecent().args[0]).toBe(bahmniVisitUrl);
         expect(mockHttp.post.calls.mostRecent().args[1]).toBe(visitDetails);
         expect(mockHttp.post.calls.mostRecent().args[2].withCredentials).toBeTruthy();
     });


### PR DESCRIPTION
- Changed api to create visits for a patient to a new Api which is getting called from bahmni-core instead of openmrs directly
- Active patient with active visit at the same location cannot create visit.