### PR TITLE
Parvathy | BAH-2805 | Fix. Copy Error Button

### DIFF
--- a/ui/app/common/ui-helper/controllers/messageController.js
+++ b/ui/app/common/ui-helper/controllers/messageController.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('bahmni.common.uiHelper')
-    .controller('MessageController', ['$scope', 'messagingService',
-        function ($scope, messagingService) {
+    .controller('MessageController', ['$scope', 'messagingService', '$translate',
+        function ($scope, messagingService, $translate) {
             $scope.messages = messagingService.messages;
 
             $scope.getMessageText = function (level) {
@@ -10,10 +10,11 @@ angular.module('bahmni.common.uiHelper')
                 $scope.messages[level].forEach(function (message) {
                     string = string.concat(message.value);
                 });
+                var translatedMessage = $translate.instant(string);
 
-                navigator.clipboard.writeText(string);
+                navigator.clipboard.writeText(translatedMessage);
 
-                return string;
+                return translatedMessage;
             };
 
             $scope.hideMessage = function (level) {

--- a/ui/test/unit/common/ui-helper/controllers/messageController.spec.js
+++ b/ui/test/unit/common/ui-helper/controllers/messageController.spec.js
@@ -4,7 +4,7 @@ describe("MessageController", function () {
 
     beforeEach(module('bahmni.common.uiHelper'));
 
-    var scope, controller, rootScope, messagingService;
+    var scope, controller, rootScope, messagingService, translate;
 
     beforeEach(inject(function ($controller, $rootScope) {
         controller = $controller;
@@ -13,9 +13,18 @@ describe("MessageController", function () {
         messagingService = jasmine.createSpyObj("messagingService", ["hideMessages"]);
     }));
 
+    var translatedMessages = {
+        "SERVERERROR":"thisisservererror"
+    };
+    translate = jasmine.createSpyObj('$translate', ['instant']);
+    translate.instant.and.callFake(function (key) {
+        return translatedMessages[key];
+    });
+
     function createController() {
         return controller("MessageController", {
             $scope: scope,
+            $translate: translate,
             messagingService : messagingService
         });
     }
@@ -31,7 +40,8 @@ describe("MessageController", function () {
     describe("method getMessageText", function () {
         it("should return concatenated message for the specified level", function () {
             createController();
-            scope.messages = {error:[{'value':'this'},{'value':"is"} ,{'value':"server"} ,{'value':"error"}]};
+            scope.messages = {error:[{'value':'SERVER'},{'value':"ERROR"}]};
+
             expect(scope.getMessageText('error')).toBe("thisisservererror");
         });
     });


### PR DESCRIPTION
Jira card -> https://bahmni.atlassian.net/browse/BAH-2805

The issue with the copy error button in the error popup has been resolved in this PR. Previously, the button was copying the translate key instead of the error message (translate value). This PR includes the necessary fixes to ensure that the  error message is correctly copied when the button is clicked.