### PR TITLE
BAH-3054 | Search by a number provides incorrect results in IPD grid view

### DIFF
--- a/ui/app/adt/controllers/wardListController.js
+++ b/ui/app/adt/controllers/wardListController.js
@@ -17,8 +17,6 @@ angular.module('bahmni.adt')
                     return true;
                 }
                 searchText = searchText.toLowerCase();
-                var admisisonTime = row["Admission Time"];
-                console.log(admisisonTime);
                 return (
                     (row.Bed && row.Bed.toLowerCase().includes(searchText)) ||
                     (row.Ward && row.Ward.toLowerCase().includes(searchText)) ||

--- a/ui/app/adt/controllers/wardListController.js
+++ b/ui/app/adt/controllers/wardListController.js
@@ -9,6 +9,30 @@ angular.module('bahmni.adt')
                 $window.location = appService.getAppDescriptor().formatUrl(Bahmni.ADT.Constants.ipdDashboard, options, true);
             };
 
+            $scope.searchText = '';
+
+            $scope.searchTextFilter = function (row) {
+                var searchText = $scope.searchText;
+                if (!searchText) {
+                    return true;
+                }
+                searchText = searchText.toLowerCase();
+                var admisisonTime = row["Admission Time"];
+                console.log(admisisonTime);
+                return (
+                    (row.Bed && row.Bed.toLowerCase().includes(searchText)) ||
+                    (row.Ward && row.Ward.toLowerCase().includes(searchText)) ||
+                    (row.Id && row.Id.toLowerCase().includes(searchText)) ||
+                    (row.Name && row.Name.toLowerCase().includes(searchText)) ||
+                    (row.Age && row.Age.toString().includes(searchText)) ||
+                    (row.Gender && row.Gender.toLowerCase().includes(searchText)) ||
+                    (row["Admission Time"] && row["Admission Time"].toLowerCase().includes(searchText)) ||
+                    (row["Disposition By"] && row["Disposition By"].toLowerCase().includes(searchText)) ||
+                    (row["Disposition Time"] && row["Disposition Time"].toLowerCase().includes(searchText)) ||
+                    (row["ADT Notes"] && row["ADT Notes"].toLowerCase().includes(searchText))
+                );
+            };
+            
             var getTableDetails = function () {
                 var params = {
                     q: "emrapi.sqlGet.wardsListDetails",

--- a/ui/app/adt/controllers/wardListController.js
+++ b/ui/app/adt/controllers/wardListController.js
@@ -10,25 +10,20 @@ angular.module('bahmni.adt')
             };
 
             $scope.searchText = '';
-
+                        
             $scope.searchTextFilter = function (row) {
                 var searchText = $scope.searchText;
                 if (!searchText) {
                     return true;
                 }
                 searchText = searchText.toLowerCase();
-                return (
-                    (row.Bed && row.Bed.toLowerCase().includes(searchText)) ||
-                    (row.Ward && row.Ward.toLowerCase().includes(searchText)) ||
-                    (row.Id && row.Id.toLowerCase().includes(searchText)) ||
-                    (row.Name && row.Name.toLowerCase().includes(searchText)) ||
-                    (row.Age && row.Age.toString().includes(searchText)) ||
-                    (row.Gender && row.Gender.toLowerCase().includes(searchText)) ||
-                    (row["Admission Time"] && row["Admission Time"].toLowerCase().includes(searchText)) ||
-                    (row["Disposition By"] && row["Disposition By"].toLowerCase().includes(searchText)) ||
-                    (row["Disposition Time"] && row["Disposition Time"].toLowerCase().includes(searchText)) ||
-                    (row["ADT Notes"] && row["ADT Notes"].toLowerCase().includes(searchText))
-                );
+                const excludedKeys = ["hiddenAttributes", "$$hashKey", "Diagnosis"];
+                const attributes = Object.keys(row).filter(key => !excludedKeys.includes(key));
+
+                return attributes.some(function (attribute) {
+                    const rowValue = row[attribute].toString();
+                    return rowValue && rowValue.toLowerCase().includes(searchText);
+                });
             };
             
             var getTableDetails = function () {

--- a/ui/app/adt/views/wardList.html
+++ b/ui/app/adt/views/wardList.html
@@ -10,7 +10,7 @@
             </tr>
         </thead>
         <tbody>
-        <tr ng-repeat="row in tableDetails | filter:searchText">
+        <tr ng-repeat="row in tableDetails | filter:searchTextFilter">
                 <td ng-repeat="heading in tableHeadings" ng-if="heading != 'hiddenAttributes'">
                     <span ng-if="heading != 'Diagnosis' && heading != 'Id'">{{row[heading]}}</span>
                     <a ng-if="heading =='Id'" ng-click="gotoPatientDashboard(row['hiddenAttributes'].patientUuid, row['hiddenAttributes'].visitUuid)">


### PR DESCRIPTION
**Context:** On ADT page, search looked up all the values coming from API. It should only search through the columns which are displayed in the grid.


- The original filter used was an Angular filter. It took a JavaScript object as input and checked if the search string is present anywhere in that object.
- The JavaScript object contains patient data such as name, age, bed number, as well as additional information like visitUUID and patientUUID.
- The behavior of the original filter was to display any patient object that had the search string present in any of its properties.
- To achieve a more specific and controlled filtering, this PR applies an additional filter. This new filter considers only certain given values (like name, age, bed number [columns present in the table]) for filtering and ignores other patient properties.


