### PR TITLE
BS-148 | Adding support for multiple prefix search in drug order

### DIFF
--- a/ui/app/clinical/consultation/models/drugSearchResult.js
+++ b/ui/app/clinical/consultation/models/drugSearchResult.js
@@ -18,7 +18,9 @@ Bahmni.Clinical.DrugSearchResult = (function () {
     var getMatcher = function (searchString) {
         return function (value) {
             // return value.search(new RegExp(searchString, "i")) !== -1
-            return _.includes(value.toLowerCase(), searchString.toLowerCase());
+            return _.every(searchString.split(" "), function (word) {
+                return _.includes(value.toLowerCase(), word.toLowerCase());
+            });
         };
     };
     var getSynonymCreator = function (drug) {

--- a/ui/test/unit/clinical/models/drugSearchResult.spec.js
+++ b/ui/test/unit/clinical/models/drugSearchResult.spec.js
@@ -58,6 +58,20 @@ describe("DrugSchedule", function () {
             expect(allMatchingSynonyms[0].label).toBe("paracetamoluse => Paracetamol 200mg");
         });
 
+        it("should return only the search results of drugs whose name matches with multiple prefix search string",function () {
+            var drug = {name: "Diphenhydramine hydrochloride 25 mg tablet", dosageForm: null, concept:{
+                    names:[
+                        {name:"Diphenhydramine hydrochloride"}
+                    ]
+                }};
+
+            var searchString = "Diph hy";
+            var allMatchingSynonyms = Bahmni.Clinical.DrugSearchResult.getAllMatchingSynonyms(drug, searchString);
+
+            expect(allMatchingSynonyms.length).toBe(1);
+            expect(allMatchingSynonyms[0].label).toBe("Diphenhydramine hydrochloride 25 mg tablet");
+        });
+
         it("should return unique list of search results when more than one name is same",function () {
             var drug = {name: "Paracetamol 200mg", dosageForm: null, concept:{
                 names:[


### PR DESCRIPTION
JIRA => https://bahmni.atlassian.net/browse/BS-148

- Even though, api call `openmrs/ws/rest/v1/drug?q=Diph+hyd&s=ordered&v=..` fetching results, we are still not returning the drugs only prefix matches.

Screenshot 

<img width="847" alt="image" src="https://github.com/Bahmni/openmrs-module-bahmniapps/assets/56538788/3a42a916-42c8-441e-a283-ca1c8956a05f">
