### PR TITLE
BAH-3102 | Add. Configurable Additional Patient Identifiers In Patient Dashboard

### DIFF
--- a/ui/app/common/displaycontrols/patientprofile/views/patientProfile.html
+++ b/ui/app/common/displaycontrols/patientprofile/views/patientProfile.html
@@ -36,9 +36,10 @@
                     <td class="value" ng-if="::!patient[attribute].isDateField">{{::(patient[attribute].value.display || patient[attribute].value) | booleanFilter}}</td>
                     <td class="value" ng-if="::patient[attribute].isDateField">{{::patient[attribute].value | bahmniDate}}</td>
                 </tr>
-                <tr ng-repeat="additionalIdentifier in patient.additionalIdentifiers" ng-show="patient.additionalIdentifiers.length" ng-class="attribute">
-                  <td class="name">{{additionalIdentifier.identifierType.display}}</td>
-                  <td class="value">{{additionalIdentifier.identifier}}</td>
+                <tr ng-repeat="attribute in config.additionalPatientIdentifiers" ng-if="::patient.additionalIdentifiers[attribute]"
+                    ng-show="::config.additionalPatientIdentifiers.length" ng-class="attribute">
+                    <td class="name">{{patient.additionalIdentifiers[attribute].label}}</td>
+                    <td class="value">{{patient.additionalIdentifiers[attribute].value}}</td>
                 </tr>
                 <tr ng-if="::relationships && relationships.length > 0">
                     <td>{{ 'PATIENT_PROFILE_RELATIONSHIPS_LABEL'|translate }}</td>

--- a/ui/app/common/displaycontrols/patientprofile/views/patientProfile.html
+++ b/ui/app/common/displaycontrols/patientprofile/views/patientProfile.html
@@ -36,6 +36,10 @@
                     <td class="value" ng-if="::!patient[attribute].isDateField">{{::(patient[attribute].value.display || patient[attribute].value) | booleanFilter}}</td>
                     <td class="value" ng-if="::patient[attribute].isDateField">{{::patient[attribute].value | bahmniDate}}</td>
                 </tr>
+                <tr ng-repeat="additionalIdentifier in patient.additionalIdentifiers" ng-show="patient.additionalIdentifiers.length" ng-class="attribute">
+                  <td class="name">{{additionalIdentifier.identifierType.display}}</td>
+                  <td class="value">{{additionalIdentifier.identifier}}</td>
+                </tr>
                 <tr ng-if="::relationships && relationships.length > 0">
                     <td>{{ 'PATIENT_PROFILE_RELATIONSHIPS_LABEL'|translate }}</td>
                 </tr>

--- a/ui/app/common/patient/mappers/patientMapper.js
+++ b/ui/app/common/patient/mappers/patientMapper.js
@@ -29,6 +29,10 @@ Bahmni.PatientMapper = function (patientConfig, $rootScope, $translate) {
             patient.identifier = primaryIdentifier ? primaryIdentifier : openmrsPatient.identifiers[0].identifier;
         }
 
+        if (openmrsPatient.identifiers.length > 1) {
+            patient.additionalIdentifiers = openmrsPatient.identifiers.slice(1);
+        }
+
         if (openmrsPatient.person.birthdate) {
             patient.birthdate = parseDate(openmrsPatient.person.birthdate);
         }

--- a/ui/app/common/patient/mappers/patientMapper.js
+++ b/ui/app/common/patient/mappers/patientMapper.js
@@ -29,7 +29,7 @@ Bahmni.PatientMapper = function (patientConfig, $rootScope, $translate) {
             patient.identifier = primaryIdentifier ? primaryIdentifier : openmrsPatient.identifiers[0].identifier;
         }
 
-        if (openmrsPatient.identifiers.length > 1) {
+        if (openmrsPatient.identifiers && openmrsPatient.identifiers.length > 1) {
             patient.additionalIdentifiers = parseIdentifiers(openmrsPatient.identifiers.slice(1));
         }
 
@@ -102,7 +102,7 @@ Bahmni.PatientMapper = function (patientConfig, $rootScope, $translate) {
     var parseIdentifiers = function (identifiers) {
         var parseIdentifiers = {};
         identifiers.forEach(function (identifier) {
-            if (identifier) {
+            if (identifier.identifierType) {
                 var label = identifier.identifierType.display;
                 parseIdentifiers[label] = {"label": label, "value": identifier.identifier};
             }

--- a/ui/app/common/patient/mappers/patientMapper.js
+++ b/ui/app/common/patient/mappers/patientMapper.js
@@ -30,7 +30,7 @@ Bahmni.PatientMapper = function (patientConfig, $rootScope, $translate) {
         }
 
         if (openmrsPatient.identifiers.length > 1) {
-            patient.additionalIdentifiers = openmrsPatient.identifiers.slice(1);
+            patient.additionalIdentifiers = parseIdentifiers(openmrsPatient.identifiers.slice(1));
         }
 
         if (openmrsPatient.person.birthdate) {
@@ -97,6 +97,17 @@ Bahmni.PatientMapper = function (patientConfig, $rootScope, $translate) {
             return Bahmni.Common.Util.DateUtil.parse(dateStr.substr(0, 10));
         }
         return dateStr;
+    };
+
+    var parseIdentifiers = function (identifiers) {
+        var parseIdentifiers = {};
+        identifiers.forEach(function (identifier) {
+            if (identifier) {
+                var label = identifier.identifierType.display;
+                parseIdentifiers[label] = {"label": label, "value": identifier.identifier};
+            }
+        });
+        return parseIdentifiers;
     };
 
     var mapGenderText = function (genderChar) {

--- a/ui/test/unit/common/patient/mappers/patientMapper.spec.js
+++ b/ui/test/unit/common/patient/mappers/patientMapper.spec.js
@@ -54,6 +54,49 @@ describe('patient mapper', function () {
         expect(patientMapper.mapBasic(patient).identifier).toEqual('OS1234');
     });
 
+    it("should map additional identifiers if more than one identifier is there", function () {
+        var patient = {
+            "person": {
+                "birthdate": "1984-08-10T14:16:34.994+0530",
+                "birthdateEstimated": true,
+                "gender": "M",
+                "birthtime": "1970-01-01T04:20:00.000+0530",
+                "preferredName": {
+                    "givenName": "Test",
+                    "familyName": "Patient"
+                },
+                "preferredAddress": {
+                    "preferred": true,
+                    "address1": "Ad56",
+                    "address2": null,
+                    "address3": "Baria",
+                    "address4": "Unions Of Gazipur Sadar Upazila",
+                    "address5": "Gazipur Sadar",
+                    "address6": null,
+                    "cityVillage": null,
+                    "countyDistrict": "Gazipur",
+                    "stateProvince": "Dhaka",
+                    "postalCode": null,
+                    "country": null
+                }
+            },
+            "identifiers": [{
+                "identifier": "OS1234",
+                "primaryIdentifier": "BDH202048",
+                "extraIdentifiers": {"OpenMRS Identification Number": "OS1234"}
+            }, {
+                "identifier": "1234567891123",
+                "primaryIdentifier": undefined,
+                "identifierType": {
+                    "uuid": "ada0b55b-0e3e-11ee-9960-0242ac150002",
+                    "display": "ABHA Number",
+                },
+            }],
+            "uuid": "8a76aad9-9a2a-4686-de9c-caf0c89bc89c"
+        };
+        expect(patientMapper.mapBasic(patient).additionalIdentifiers).toEqual({ "ABHA Number" : { label : 'ABHA Number', value : '1234567891123' } } );
+    });
+    
     it("should map primary identifier if it is there", function () {
         var patient = {
             "person": {


### PR DESCRIPTION
Jira -> [BAH-3102](https://bahmni.atlassian.net/browse/BAH-3102)

In this PR, a configurable property of "additionalPatientIdentifiers" is introduced. The purpose of this is to enable the visibility of additional patient identifiers for users with the privilege to view the patient dashboard.

To implement this feature, modifications are to be made to the [openmrs/apps/clinical/dashboard.json](https://github.com/BahmniIndiaDistro/clinic-config/blob/main/openmrs/apps/clinical/dashboard.json) file. Within the "sections/patientInformation", the "additionalPatientIdentifiers" property can be configured to specify the desired additional identifiers to be displayed.

For example, if "additionalPatientIdentifiers" is set to ["ABHA Address","ABHA Number"], the patient dashboard will display these additional identifiers alongside other patient information.

- When "additionalPatientIdentifiers" is configured:
![Screenshot 2023-07-13 at 12 49 57 PM](https://github.com/Bahmni/openmrs-module-bahmniapps/assets/121226043/4f2e2e2e-f7e1-41cc-844a-146b46cea8c0)

- When additionalPatientIdentifiers is left empty: 
![Screenshot 2023-07-13 at 12 50 26 PM](https://github.com/Bahmni/openmrs-module-bahmniapps/assets/121226043/70738154-5ce0-4387-81c7-8605f886e71c)
