### PR TITLE
Phani | A - 1205069439065526 | Add template options for notes in lab/radiology orders

### DIFF
--- a/ui/app/clinical/consultation/controllers/orderController.js
+++ b/ui/app/clinical/consultation/controllers/orderController.js
@@ -12,6 +12,7 @@ angular.module('bahmni.clinical')
             $scope.enableLabOrderOptions = LabOrderOptionsConfig ? LabOrderOptionsConfig.value : null;
             var testConceptToParentsMapping = {}; // A child concept could be part of multiple parent panels
             $scope.hideLabTests = true;
+            $scope.noteOptions = appService.getAppDescriptor().getConfigValue("orderNotes");
 
             var collapseExistingActiveSection = function (section) {
                 if (section) {
@@ -225,6 +226,23 @@ angular.module('bahmni.clinical')
                     $scope.orderNoteText = printNotes + (order.previousNote || '');
                 } else if (($scope.orderNoteText || '').indexOf(printNotes) == -1) {
                     $scope.orderNoteText = $translate.instant(printNotes) + ($scope.orderNoteText || '');
+                }
+            };
+
+            $scope.shouldShowNoteOptions = function (orderId, noteName) {
+                var configuredOptions = $scope.noteOptions;
+                return _.some(configuredOptions, function (option) {
+                    return option.label.toLowerCase() === noteName.toLowerCase();
+                })
+                    && !orderId;
+            };
+
+            $scope.appendNotes = function (order, noteKey) {
+                const notesToAppend = $translate.instant(noteKey);
+                if (order.previousNote && !order.previousNote.includes(notesToAppend)) {
+                    $scope.orderNoteText = ((order.previousNote + '\n') || '') + notesToAppend;
+                } else if (!($scope.orderNoteText || '').includes(notesToAppend)) {
+                    $scope.orderNoteText = ($scope.orderNoteText ? $scope.orderNoteText + '\n' : '') + notesToAppend;
                 }
             };
 

--- a/ui/app/clinical/consultation/views/orderNotes.html
+++ b/ui/app/clinical/consultation/views/orderNotes.html
@@ -5,7 +5,7 @@
     <button ng-click="appendPrintNotes(ngDialogData)" class="fl btn-group" ng-show="isPrintShown(ngDialogData.uuid)">{{ 'CLINICAL_ORDER_RADIOLOGY_NEED_PRINT_BUTTON' | translate}}</button>
     <div style="width: 80%">
         <div ng-repeat=" note in noteOptions">
-            <button style="margin-right: 2px;" ng-click="appendNotes(ngDialogData, note.translationKey)" ng-show="shouldShowNoteOptions(ngDialogData.uuid, note.label)" class="fl btn-group">{{note.label}}</button>
+            <button ng-click="appendNotes(ngDialogData, note.translationKey)" ng-show="shouldShowNoteOptions(ngDialogData.uuid, note.label)" class="fl btn-group order-notes-button">{{note.label}}</button>
         </div>
     </div>
 

--- a/ui/app/clinical/consultation/views/orderNotes.html
+++ b/ui/app/clinical/consultation/views/orderNotes.html
@@ -3,6 +3,12 @@
 
     <textarea ng-model="$parent.orderNoteText" focus-on="true" rows="4" ng-disabled="ngDialogData.uuid">{{ngDialogData.previousNote}}</textarea>
     <button ng-click="appendPrintNotes(ngDialogData)" class="fl btn-group" ng-show="isPrintShown(ngDialogData.uuid)">{{ 'CLINICAL_ORDER_RADIOLOGY_NEED_PRINT_BUTTON' | translate}}</button>
+    <div style="width: 80%">
+        <div ng-repeat=" note in noteOptions">
+            <button style="margin-right: 2px;" ng-click="appendNotes(ngDialogData, note.translationKey)" ng-show="shouldShowNoteOptions(ngDialogData.uuid, note.label)" class="fl btn-group">{{note.label}}</button>
+        </div>
+    </div>
+
     <div class="btn-group fr">
         <span ng-if="ngDialogData.uuid">
             {{ 'ORDER_CAN_NOT_EDIT_AFTER_SAVE_MESSAGE'|translate }}

--- a/ui/app/common/concept-set/directives/conceptSet.js
+++ b/ui/app/common/concept-set/directives/conceptSet.js
@@ -29,7 +29,7 @@ angular.module('bahmni.common.conceptSet')
                 };
 
                 var updateObservationsOnRootScope = function () {
-                    if ($scope.rootObservation) {
+                    if ($scope.rootObservation && $scope.observations) {
                         for (var i = 0; i < $scope.observations.length; i++) {
                             if ($scope.observations[i].concept.uuid === $scope.rootObservation.concept.uuid) {
                                 $scope.observations[i] = $scope.rootObservation;
@@ -290,10 +290,10 @@ angular.module('bahmni.common.conceptSet')
                             $scope.rootObservation.conceptSetName = $scope.conceptSetName;
                             focusFirstObs();
                             updateObservationsOnRootScope();
-                            var groupMembers = getObservationsOfCurrentTemplate()[0].groupMembers;
+                            var observations = getObservationsOfCurrentTemplate();
                             var defaults = getDefaults();
                             addDummyImage();
-                            setDefaultsForGroupMembers(groupMembers, defaults);
+                            setDefaultsForGroupMembers(observations && observations[0] && observations[0].groupMembers, defaults);
                             var observationsOfCurrentTemplate = getObservationsOfCurrentTemplate();
                             updateFormConditions(observationsOfCurrentTemplate, $scope.rootObservation);
                         } else {

--- a/ui/app/common/patient-search/constants.js
+++ b/ui/app/common/patient-search/constants.js
@@ -5,7 +5,7 @@ Bahmni.Common.PatientSearch = Bahmni.Common.PatientSearch || {};
 Bahmni.Common.PatientSearch.Constants = {
     searchExtensionTileViewType: "tile",
     searchExtensionTabularViewType: "tabular",
-    tabularViewIgnoreHeadingsList: ["display", "uuid", "image", "$$hashKey", "activeVisitUuid", "hasBeenAdmitted", "forwardUrl", "programUuid", "enrollment", "extraIdentifier"],
+    tabularViewIgnoreHeadingsList: ["display", "uuid", "image", "$$hashKey", "activeVisitUuid", "hasBeenAdmitted", "forwardUrl", "programUuid", "enrollment", "extraIdentifier", "kid"],
     identifierHeading: ["ID", "Id", "id", "identifier", "DQ_COLUMN_TITLE_ACTION", "Patient ID"],
     nameHeading: ["NAME", "Name", "name"],
     patientTileHeight: 100,

--- a/ui/app/common/patient-search/controllers/patientsListController.js
+++ b/ui/app/common/patient-search/controllers/patientsListController.js
@@ -101,13 +101,11 @@ angular.module('bahmni.common.patientSearch')
 
         var setActiveHeadings = function (headings) {
             headings.map(function (heading) {
-                if (heading !== personAttributeForPatientSearch) {
-                    var newHeading = { name: heading, sortInfo: heading };
-                    if (!$scope.activeHeaders.find(function (activeHeader) {
-                        return activeHeader.name == newHeading.name && activeHeader.sortInfo == newHeading.sortInfo;
-                    })) {
-                        $scope.activeHeaders.push(newHeading);
-                    }
+                var newHeading = { name: heading, sortInfo: heading };
+                if (!$scope.activeHeaders.find(function (activeHeader) {
+                    return activeHeader.name == newHeading.name && activeHeader.sortInfo == newHeading.sortInfo;
+                })) {
+                    $scope.activeHeaders.push(newHeading);
                 }
             });
         };

--- a/ui/app/i18n/clinical/locale_en.json
+++ b/ui/app/i18n/clinical/locale_en.json
@@ -376,5 +376,11 @@
   "SIGN_SYMPTOM_DURATION_KEY": "Sign/symptom duration",
   "CHIEF_COMPLAINT_DURATION_UNIT_KEY": "Chief Complaint Duration",
   "DASHBOARD_IPD_DRUG_CHART_TAB_KEY": "Drug Chart",
-  "DASHBOARD_NEXT_UI_ALLERGIES_KEY": "Allergies"
+  "DASHBOARD_NEXT_UI_ALLERGIES_KEY": "Allergies",
+  "PRE_OP": "Pre-operative X-ray for diagnostic or planning purposes",
+  "POST_OP": "Post-operative X-ray for assessing healing or implant position",
+  "MONITORING": "Monitoring of progress for alignment / comparative purposes",
+  "FROM_CLINIC": "Request from clinic",
+  "FROM_WARD": "Request from ward",
+  "HIGH_RISK": "High Risk"
 }

--- a/ui/app/orders/controllers/orderFulfillmentController.js
+++ b/ui/app/orders/controllers/orderFulfillmentController.js
@@ -43,6 +43,7 @@ angular.module('bahmni.orders').controller('OrderFulfillmentController', ['$scop
                 var data = response.data;
                 $scope.orders.push.apply($scope.orders, data);
                 $scope.orders.forEach(function (order) {
+                    order.commentToFulfiller = order.commentToFulfiller.replace('\n', ' | ');
                     order.bahmniObservations = _.filter($scope.encounter.observations, function (observation) {
                         return observation.orderUuid === order.orderUuid;
                     });

--- a/ui/app/orders/controllers/orderFulfillmentController.js
+++ b/ui/app/orders/controllers/orderFulfillmentController.js
@@ -43,7 +43,7 @@ angular.module('bahmni.orders').controller('OrderFulfillmentController', ['$scop
                 var data = response.data;
                 $scope.orders.push.apply($scope.orders, data);
                 $scope.orders.forEach(function (order) {
-                    order.commentToFulfiller = order.commentToFulfiller.replace('\n', ' | ');
+                    order.commentToFulfiller = order.commentToFulfiller && order.commentToFulfiller.replaceAll('\n', ' | ');
                     order.bahmniObservations = _.filter($scope.encounter.observations, function (observation) {
                         return observation.orderUuid === order.orderUuid;
                     });

--- a/ui/app/orders/views/orderFulfillment.html
+++ b/ui/app/orders/views/orderFulfillment.html
@@ -20,10 +20,10 @@
                 <div ng-if="order.showForm">
                     <orders-control patient="patient" order-uuid="order.orderUuid" config="config" message="message"
                                     show-title="false"></orders-control>
-                    <div style="margin: 0 10px">
+                    <div class="order-note">
                         <i ng-if="::(order.urgency === 'STAT')" class="fa fa-exclamation-triangle fa-orange show-before-active"></i>
                         <i ng-if="::order.commentToFulfiller" class="fa fa-comments"></i>
-                        <span ng-if="::order.commentToFulfiller">{{order.commentToFulfiller}}<br><br></span>
+                        <span ng-if="::order.commentToFulfiller" class="note">{{order.commentToFulfiller}}<br><br></span>
                         <span>Provider: {{order.provider}}</span>
                     </div>
                     <concept-set patient="patient" ng-if="order.showForm"

--- a/ui/app/orders/views/orderFulfillment.html
+++ b/ui/app/orders/views/orderFulfillment.html
@@ -20,9 +20,11 @@
                 <div ng-if="order.showForm">
                     <orders-control patient="patient" order-uuid="order.orderUuid" config="config" message="message"
                                     show-title="false"></orders-control>
-                    <div>
+                    <div style="margin: 0 10px">
+                        <i ng-if="::(order.urgency === 'STAT')" class="fa fa-exclamation-triangle fa-grey show-before-active"></i>
                         <i ng-if="::order.commentToFulfiller" class="fa fa-comments"></i>
-                        <span>{{order.commentToFulfiller}}</span>
+                        <span>{{order.commentToFulfiller}}</span><br><br>
+                        <span>Provider: {{order.provider}}</span>
                     </div>
                     <concept-set patient="patient" ng-if="order.showForm"
                                  concept-set-name="formName"

--- a/ui/app/orders/views/orderFulfillment.html
+++ b/ui/app/orders/views/orderFulfillment.html
@@ -21,9 +21,9 @@
                     <orders-control patient="patient" order-uuid="order.orderUuid" config="config" message="message"
                                     show-title="false"></orders-control>
                     <div style="margin: 0 10px">
-                        <i ng-if="::(order.urgency === 'STAT')" class="fa fa-exclamation-triangle fa-grey show-before-active"></i>
+                        <i ng-if="::(order.urgency === 'STAT')" class="fa fa-exclamation-triangle fa-orange show-before-active"></i>
                         <i ng-if="::order.commentToFulfiller" class="fa fa-comments"></i>
-                        <span>{{order.commentToFulfiller}}</span><br><br>
+                        <span ng-if="::order.commentToFulfiller">{{order.commentToFulfiller}}<br><br></span>
                         <span>Provider: {{order.provider}}</span>
                     </div>
                     <concept-set patient="patient" ng-if="order.showForm"

--- a/ui/app/styles/clinical/_orders.scss
+++ b/ui/app/styles/clinical/_orders.scss
@@ -519,6 +519,17 @@
         border-left: #ddd 1px solid !important;
     }
 }
+.order-notes-button{
+    margin-right: 2px;
+    width: 115px
+}
+
+.order-note{
+    margin: 0 10px;
+    .note{
+        line-height: 20px;
+    }
+}
 
 .hierarchy ul li.image-preview {
     display: inline-block;

--- a/ui/test/unit/clinical/controllers/orderController.spec.js
+++ b/ui/test/unit/clinical/controllers/orderController.spec.js
@@ -30,6 +30,12 @@ describe("OrderController", function () {
                 };
             }
         };
+        appDescriptor.getConfigValue = function (param) {
+            return [{
+                "label": "OP",
+                "translationKey": "OP_KEY"
+            }]
+        }
         appServiceMock.getAppDescriptor = function() { return appDescriptor };
 
         var translate = jasmine.createSpyObj('$translate',['instant']);


### PR DESCRIPTION
This PR adds options in the create notes popup while creating an order. The note after saving is then shown in the Orders module
Options and the template text:
<img width="616" alt="Screenshot 2023-08-01 at 3 49 06 PM" src="https://github.com/Bahmni/openmrs-module-bahmniapps/assets/126503818/ea6bd992-1154-4181-ab66-d8782ceb1377">
The order after saving will show in orders section:
<img width="1329" alt="Screenshot 2023-08-01 at 2 59 04 PM" src="https://github.com/Bahmni/openmrs-module-bahmniapps/assets/126503818/09aeda2e-fc79-4672-99a2-f2f9b9a0728c">

This PR also 
1. Removes the kid column coming up in Orders section in the patient list
2. Fixes some errors coming up in a scenario where note is empty or concept is empty