### PR TITLE
BS-160 | Filter and display only current medication alert

### DIFF
--- a/ui/app/clinical/consultation/controllers/addTreatmentController.js
+++ b/ui/app/clinical/consultation/controllers/addTreatmentController.js
@@ -78,9 +78,9 @@ angular.module('bahmni.clinical')
 
             $scope.submitAudit = function (index) {
                 var patientUuid = $scope.patient.uuid;
-                var message = $scope.cdssaAlerts[index].summary.replace(/"/g, '');
+                var message = $scope.newAlerts[index].summary.replace(/"/g, '');
                 var eventType = 'Dismissed: ' + $scope.treatment.audit;
-                $scope.cdssaAlerts.splice(index, 1);
+                $scope.newAlerts.splice(index, 1);
                 return drugService
                 .cdssAudit(patientUuid, eventType, message, 'CDSS')
                 .then(function () {
@@ -516,14 +516,14 @@ angular.module('bahmni.clinical')
             };
 
             $scope.closeAlert = function (index) {
-                $scope.cdssaAlerts = $scope.cdssaAlerts.filter(function (alert, alertIndex) {
+                $scope.newAlerts = $scope.newAlerts.filter(function (_alert, alertIndex) {
                     return alertIndex !== index;
                 });
             };
 
             $scope.toggleAlertDetails = function (index) {
-                $scope.cdssaAlerts[index].showDetails =
-                  !$scope.cdssaAlerts[index].showDetails;
+                $scope.newAlerts[index].showDetails =
+                  !$scope.newAlerts[index].showDetails;
             };
 
             $scope.getDataResults = function (drugs) {
@@ -545,9 +545,7 @@ angular.module('bahmni.clinical')
                         },
                         medicationCodeableConcept: {
                             id: medication.drug.uuid,
-                            coding: [
-                                coding
-                            ],
+                            coding: coding,
                             text: medication.drugNameDisplay
                         }
                     };
@@ -558,10 +556,11 @@ angular.module('bahmni.clinical')
             };
             var extractCodeInfo = function (medication) {
                 if (!(medication.drug.drugReferenceMaps && medication.drug.drugReferenceMaps.length > 0)) {
-                    return Promise.resolve({
+                    return Promise.resolve([{
                         code: medication.drug.uuid,
-                        display: medication.drug.name
-                    });
+                        display: medication.drug.name,
+                        system: 'https://fhir.openmrs.org'
+                    }]);
                 } else {
                     var drugReferenceMap = medication.drug.drugReferenceMaps[0];
                     if (!$scope.conceptSource) {
@@ -574,24 +573,33 @@ angular.module('bahmni.clinical')
                             if (conceptCode) {
                                 localStorage.setItem("conceptSource", conceptCode.system);
                                 $scope.conceptSource = conceptCode.system;
-                                return {
+                                return [{
                                     system: $scope.conceptSource,
                                     code: drugReferenceMap.conceptReferenceTerm && drugReferenceMap.conceptReferenceTerm.display && drugReferenceMap.conceptReferenceTerm.display.split(':')[1].trim(),
                                     display: medication.drug.name
-                                };
-                            } else {
-                                return {
+                                }, {
                                     code: medication.drug.uuid,
+                                    system: 'https://fhir.openmrs.org',
                                     display: medication.drug.name
-                                };
+                                }];
+                            } else {
+                                return [{
+                                    code: medication.drug.uuid,
+                                    display: medication.drug.name,
+                                    system: 'https://fhir.openmrs.org'
+                                }];
                             }
                         });
                     } else {
-                        return Promise.resolve({
+                        return Promise.resolve([{
                             system: $scope.conceptSource,
                             code: drugReferenceMap.conceptReferenceTerm && drugReferenceMap.conceptReferenceTerm.display && drugReferenceMap.conceptReferenceTerm.display.split(':')[1].trim(),
                             display: medication.drug.name
-                        });
+                        }, {
+                            code: medication.drug.uuid,
+                            system: 'https://fhir.openmrs.org',
+                            display: medication.drug.name
+                        }]);
                     }
                 }
             };
@@ -681,6 +689,19 @@ angular.module('bahmni.clinical')
                 });
             }
 
+            function filterNewAlerts (cdssAlerts, drugMaps) {
+                return cdssAlerts.filter(function (alert) {
+                    if (alert.referenceMedication && alert.referenceMedication.coding && alert.referenceMedication.coding.length > 0) {
+                        var codes = [];
+                        alert.referenceMedication.coding.forEach(function (item) {
+                            codes.push(item.code);
+                        });
+
+                        return drugMaps[1] && codes.indexOf(drugMaps[1].trim()) !== -1;
+                    }
+                });
+            }
+
             (function () {
                 var selectedItem;
                 $scope.onSelect = function (item) {
@@ -696,9 +717,12 @@ angular.module('bahmni.clinical')
                         var params = createParams(consultationData);
                         $scope.createFhirBundle(params.patient, params.conditions, params.medications, params.diagnosis)
                         .then(function (bundle) {
-                            var cdssaAlerts = drugService.sendDiagnosisDrugBundle(bundle);
-                            cdssaAlerts.then(function (response) {
-                                $scope.cdssaAlerts = sortInteractionsByStatus(response.data);
+                            var cdssAlerts = drugService.sendDiagnosisDrugBundle(bundle);
+                            var drug = consultationData.draftDrug[0].drug;
+                            var drugMaps = drug.drugReferenceMaps[0] ? drug.drugReferenceMaps[0].conceptReferenceTerm.display.split(':') : [];
+                            cdssAlerts.then(function (response) {
+                                $scope.cdssAlerts = sortInteractionsByStatus(response.data);
+                                $scope.newAlerts = filterNewAlerts($scope.cdssAlerts, drugMaps);
                             });
                         });
                     }
@@ -729,14 +753,14 @@ angular.module('bahmni.clinical')
                         return;
                     }
                     delete $scope.treatment.drug;
-                    $scope.cdssaAlerts = [];
+                    $scope.cdssAlerts = [];
                 };
             })();
 
             $scope.clearForm = function () {
                 $scope.treatment = newTreatment();
                 $scope.formInvalid = false;
-                $scope.cdssaAlerts = [];
+                $scope.newAlerts = [];
                 clearHighlights();
                 markVariable("startNewDrugEntry");
             };

--- a/ui/app/clinical/consultation/views/treatmentSections/addTreatment.html
+++ b/ui/app/clinical/consultation/views/treatmentSections/addTreatment.html
@@ -259,11 +259,11 @@
                     </div>
                 </article>
 
-                <h3 ng-show="cdssaAlerts && cdssaAlerts.length > 0" class="cdss-alerts">
-                    {{"CDSS_" + cdssaAlerts[0].indicator.toUpperCase() | translate}}
+                <h3 ng-show="newAlerts && newAlerts.length > 0" class="cdss-alerts">
+                    {{"CDSS_" + newAlerts[0].indicator.toUpperCase() | translate}}
                 </h3>
 
-                    <div ng-repeat="cdssAlert in cdssaAlerts" class="cdss-alert" ng-class="{'alert-danger': cdssAlert.indicator == 'critical', 'alert-warning': cdssAlert.indicator == 'warning', 'alert-info': cdssAlert.indicator == 'info'}" ng-show="cdssAlert">
+                    <div ng-repeat="cdssAlert in newAlerts" class="cdss-alert" ng-class="{'alert-danger': cdssAlert.indicator == 'critical', 'alert-warning': cdssAlert.indicator == 'warning', 'alert-info': cdssAlert.indicator == 'info'}" ng-show="cdssAlert">
                         <button ng-disabled="cdssAlert.indicator == 'critical'" type="button" class="cdss-alert-close" ng-click="closeAlert($index)">&times;</button>
                         <i class="fa" aria-hidden="true"
                              ng-class="{'fa-exclamation-triangle': cdssAlert.indicator == 'critical' || cdssAlert.indicator == 'warning', 'fa-info-circle': cdssAlert.indicator == 'info'}"
@@ -306,7 +306,7 @@
 
                 <div class="operations fr clearfix">
                     <button class="add-drug-btn secondary-button fl" type="submit" accesskey="{{ ::treatmentConfig.translate('addAccessKey', 'MEDICATION_ADD_ACCESS_KEY') }}"
-                            ng-disabled="!treatment.drug.uuid && !treatment.concept.uuid && treatment.drugNameDisplay && !treatment.isNonCodedDrug || (cdssaAlerts && cdssaAlerts[0].indicator == 'critical')">
+                            ng-disabled="!treatment.drug.uuid && !treatment.concept.uuid && treatment.drugNameDisplay && !treatment.isNonCodedDrug || (newAlerts && newAlerts[0].indicator == 'critical')">
                              <span ng-bind-html="::treatmentConfig.translate('add', 'MEDICATION_ADD_BUTTON_LABEL')">
                         </span>
                     </button>

--- a/ui/test/unit/clinical/controllers/addTreatmentController.spec.js
+++ b/ui/test/unit/clinical/controllers/addTreatmentController.spec.js
@@ -593,26 +593,27 @@ describe("AddTreatmentController", function () {
             ];
 
             beforeEach(function () {
-                scope.cdssaAlerts = alerts;
+                scope.cdssAlerts = alerts;
+                scope.newAlerts = alerts;
             });
 
             it("should close alert on clicking close button", function () {
                 scope.closeAlert(0);
-                expect(scope.cdssaAlerts.length).toBe(0);
+                expect(scope.newAlerts.length).toBe(0);
             });
 
             it("should toggle alert details on clicking toggle button", function () {
                 scope.toggleAlertDetails(0);
-                expect(scope.cdssaAlerts[0].showDetails).toBeTruthy();
+                expect(scope.newAlerts[0].showDetails).toBeTruthy();
                 scope.toggleAlertDetails(0);
-                expect(scope.cdssaAlerts[0].showDetails).toBeFalsy();
+                expect(scope.newAlerts[0].showDetails).toBeFalsy();
             });
 
             it("should dismiss critical alert on submitting an audit", function () {
                 scope.patient = {uuid: 'some-user-uuid'};
                 scope.treatment = {audit: "some-audit"};
                 scope.submitAudit(0).then(function () {
-                    expect(scope.cdssaAlerts.length).toBe(0);
+                    expect(scope.newAlerts.length).toBe(0);
                 });
             });
         });


### PR DESCRIPTION
Jira - https://bahmni.atlassian.net/browse/BS-160

### Summary
- Display only the alert(s) related to the current drug to be added on top of the ‘Add’ button on the Medications Tab.
- For Bahmni system, use `https://fhir.openmrs.org` in the CDSS bundle payload



> <i>Only alerts relevant to the current drug are shown, despite the CDSS server's response containing alerts for other saved drugs.</i>

<img width="1680" alt="Screenshot 2023-08-09 at 12 05 10" src="https://github.com/Bahmni/openmrs-module-bahmniapps/assets/48393059/8de5afa2-fbec-4e39-8ef5-29fcc06c3ee1">
