### PR TITLE
Phani | A-1205283475057406 | Add custom sorting for flowsheet

### DIFF
--- a/ui/app/common/displaycontrols/pivottable/directives/pivotTable.js
+++ b/ui/app/common/displaycontrols/pivottable/directives/pivotTable.js
@@ -87,7 +87,7 @@ angular.module('bahmni.common.displaycontrol.pivottable').directive('pivotTable'
                         };
                     });
                     if (customSortNeeded && obsConcepts) {
-                        concepts.sort(function (a, b){
+                        concepts.sort(function (a, b) {
                             const indexOfA = obsConcepts.indexOf(a.name);
                             const indexOfB = obsConcepts.indexOf(b.name);
                             return indexOfA - indexOfB;

--- a/ui/app/common/displaycontrols/pivottable/directives/pivotTable.js
+++ b/ui/app/common/displaycontrols/pivottable/directives/pivotTable.js
@@ -17,7 +17,7 @@ angular.module('bahmni.common.displaycontrol.pivottable').directive('pivotTable'
                 }
 
                 scope.groupBy = scope.config.groupBy || "visits";
-                scope.heading = scope.config.rowHeading || scope.config.groupBy;
+                scope.heading = scope.config.rowHeading || scope.groupBy;
                 scope.groupByEncounters = scope.groupBy === "encounters";
                 scope.groupByVisits = scope.groupBy === "visits";
 

--- a/ui/app/common/displaycontrols/pivottable/directives/pivotTable.js
+++ b/ui/app/common/displaycontrols/pivottable/directives/pivotTable.js
@@ -76,7 +76,6 @@ angular.module('bahmni.common.displaycontrol.pivottable').directive('pivotTable'
                 var pivotDataPromise = pivotTableService.getPivotTableFor(scope.patientUuid, scope.config, scope.visitUuid, startDate, endDate);
                 spinner.forPromise(pivotDataPromise, element);
                 pivotDataPromise.then(function (response) {
-                    const {obsConcepts, customSortNeeded} = scope.config;
                     var concepts = _.map(response.data.conceptDetails, function (conceptDetail) {
                         return {
                             name: conceptDetail.fullName,
@@ -86,10 +85,10 @@ angular.module('bahmni.common.displaycontrol.pivottable').directive('pivotTable'
                             units: conceptDetail.units
                         };
                     });
-                    if (customSortNeeded && obsConcepts) {
+                    if (scope.config.customSortNeeded && scope.config.obsConcepts) {
                         concepts.sort(function (a, b) {
-                            const indexOfA = obsConcepts.indexOf(a.name);
-                            const indexOfB = obsConcepts.indexOf(b.name);
+                            const indexOfA = scope.config.obsConcepts.indexOf(a.name);
+                            const indexOfB = scope.config.obsConcepts.indexOf(b.name);
                             return indexOfA - indexOfB;
                         });
                     }

--- a/ui/app/common/displaycontrols/pivottable/views/pivotTable.html
+++ b/ui/app/common/displaycontrols/pivottable/views/pivotTable.html
@@ -10,7 +10,7 @@
         <table ng-class="::{'h-scroll':showOnPrint, 'pivot-table':showOnPrint, 'h-scroll-print': !showOnPrint}">
             <thead>
             <tr>
-                <th class="row-header-group">{{::groupBy}}</th>
+                <th class="row-header-group">{{::heading}}</th>
                 <th ng-repeat="concept in ::result.concepts track by $index">
                     <span>{{::concept.shortName}}</span>
                     <hint concept-details="concept"/>
@@ -34,7 +34,7 @@
                     </span>
                     </div>
                     <div ng-if="::!isLonger(columnResult.value)">
-                        <span ng-class="::{'is-abnormal': (columnResult.abnormal == true)}">{{::getColumnValue(columnResult.value, concept.name)}}</span>
+                        <span ng-class="::{'is-abnormal': (columnResult.abnormal == true)}" style="text-align: center">{{::getColumnValue(columnResult.value, concept.name)}}</span>
                     </div>
                 </td>
             </tr>

--- a/ui/app/common/displaycontrols/pivottable/views/pivotTable.html
+++ b/ui/app/common/displaycontrols/pivottable/views/pivotTable.html
@@ -34,7 +34,7 @@
                     </span>
                     </div>
                     <div ng-if="::!isLonger(columnResult.value)">
-                        <span ng-class="::{'is-abnormal': (columnResult.abnormal == true)}" style="text-align: center">{{::getColumnValue(columnResult.value, concept.name)}}</span>
+                        <span ng-class="::{'is-abnormal': (columnResult.abnormal == true)}">{{::getColumnValue(columnResult.value, concept.name)}}</span>
                     </div>
                 </td>
             </tr>


### PR DESCRIPTION
By default the rows in the Flowsheet are coming in the order of concept update DateTime, meaning which ever concept is updated last comes as first row.
In this PR based on config, If sorting this form to a specific order is needed, the data is sorted accordingly.
<img width="652" alt="Screenshot 2023-08-29 at 8 02 17 PM" src="https://github.com/Bahmni/openmrs-module-bahmniapps/assets/126503818/cc2fae2d-3842-4d86-8688-3d8a98245436">
