### PR TITLE
BAH-3229 | Fix. entire address field should be cleared before updating the address from extension point

### DIFF
--- a/ui/app/registration/controllers/patientCommonController.js
+++ b/ui/app/registration/controllers/patientCommonController.js
@@ -132,6 +132,7 @@ angular.module('bahmni.registration')
             };
 
             function updatePatientAddress (address, addressMap) {
+                $scope.patient.address = {};
                 for (var key in addressMap) {
                     if (address[key] && address[key] !== null) {
                         if (key === "line") {


### PR DESCRIPTION
if some address field is retained along with the updated address fields from extension will results in the wrong address as a whole