### PR TITLE
BAH-3181 | Configuration support for concept name label to be shown on FSN if specified

### DIFF
--- a/ui/app/common/displaycontrols/observation/directives/bahmniObservation.js
+++ b/ui/app/common/displaycontrols/observation/directives/bahmniObservation.js
@@ -19,7 +19,8 @@ angular.module('bahmni.common.displaycontrol.observation')
                     if ($scope.config.conceptNames) {
                         observations = _.filter(observations, function (observation) {
                             return _.some($scope.config.conceptNames, function (conceptName) {
-                                return _.toLower(conceptName) === _.toLower(_.get(observation, 'concept.name'));
+                                var comparableAttr = observation.conceptFSN != null ? 'conceptFSN' : 'concept.name';
+                                return _.toLower(conceptName) === _.toLower(_.get(observation, comparableAttr));
                             });
                         });
                     }

--- a/ui/app/common/displaycontrols/observation/views/observationDisplayControl.html
+++ b/ui/app/common/displaycontrols/observation/views/observationDisplayControl.html
@@ -29,7 +29,7 @@
                             <ul>
                                 <show-observation show-details-button="::config.showDetailsButton" patient="::patient"
                                                   observation="::observation"
-                                                  level="2"></show-observation>
+                                                  level="2" display-name-type="::config.displayNameType"></show-observation>
                             </ul>
                         </li>
                     </ul>
@@ -37,17 +37,17 @@
                         class="print-observations hidden-print obs-groups-container">
                         <show-observation show-details-button="::config.showDetailsButton" patient="::patient"
                                           observation="::observation" ng-repeat="observation in obsGroup.value"
-                                          level="2" config-is-observation-for-images="::config.isObservationForImages"></show-observation>
+                                          level="2" config-is-observation-for-images="::config.isObservationForImages" display-name-type="::config.displayNameType"></show-observation>
                     </ul>
                     <ul style="background-color:white;max-width:100%;overflow-x:hidden;" ng-if="::(obsGroup.isOpen && config.isObservationForImages && !isOnDashboard)" class="print-observations hidden-print"> 
                         <show-observation show-details-button="::config.showDetailsButton" patient="::patient"
                                           observation="::observation" ng-repeat="observation in obsGroup.value"
-                                          level="2" config-is-observation-for-images="::config.isObservationForImages"></show-observation>
+                                          level="2" config-is-observation-for-images="::config.isObservationForImages" display-name-type="::config.displayNameType"></show-observation>
                     </ul>
                     <ul ng-if="obsGroup.isOpen && !config.isObservationForImages" class="print-observations hidden-print">
                         <show-observation show-details-button="::config.showDetailsButton" patient="::patient"
                                           observation="::observation" ng-repeat="observation in obsGroup.value"
-                                          level="2" config-is-observation-for-images="::config.isObservationForImages"></show-observation>
+                                          level="2" config-is-observation-for-images="::config.isObservationForImages" display-name-type="::config.displayNameType"></show-observation>
                     </ul>
                 </li>
             </ul>

--- a/ui/app/common/obs/directives/showObservation.js
+++ b/ui/app/common/obs/directives/showObservation.js
@@ -33,7 +33,7 @@ angular.module('bahmni.common.obs')
             };
             $scope.displayLabel = function (observation) {
                 if ($scope.displayNameType === 'FSN') {
-                    return observation.conceptFSN || observation.concept.name;
+                    return observation.concept.name;
                 } else {
                     return (observation.concept.shortName.charAt(0).toUpperCase() + observation.concept.shortName.slice(1)) || observation.concept.name;
                 }

--- a/ui/app/common/obs/directives/showObservation.js
+++ b/ui/app/common/obs/directives/showObservation.js
@@ -31,6 +31,13 @@ angular.module('bahmni.common.obs')
                     }
                 });
             };
+            $scope.displayLabel = function (observation) {
+                if ($scope.displayNameType === 'FSN') {
+                    return observation.conceptFSN || observation.concept.name;
+                } else {
+                    return (observation.concept.shortName.charAt(0).toUpperCase() + observation.concept.shortName.slice(1)) || observation.concept.name;
+                }
+            };
         };
         return {
             restrict: 'E',
@@ -40,7 +47,8 @@ angular.module('bahmni.common.obs')
                 showDate: "=?",
                 showTime: "=?",
                 showDetailsButton: "=?",
-                configIsObservationForImages: "=?"
+                configIsObservationForImages: "=?",
+                displayNameType: "=?"
             },
             controller: controller,
             template: '<ng-include src="\'../common/obs/views/showObservation.html\'" />'

--- a/ui/app/common/obs/views/showObservation.html
+++ b/ui/app/common/obs/views/showObservation.html
@@ -13,7 +13,7 @@
             <label>{{::(observation.getDisplayValue())}}</label>
         </span>
         <span ng-if="observation.groupMembers.length==0 && !configIsObservationForImages && observation.concept.conceptClass != 'Image'" class="testUnderPanel left">
-            <label>{{::((observation.concept.shortName.charAt(0).toUpperCase() + observation.concept.shortName.slice(1)) || observation.concept.name)}}</label>
+            <label>{{::displayLabel(observation)}}</label>
             <hint concept-details="::{
             lowNormal:observation.lowNormal||observation.concept.lowNormal,
             hiNormal:observation.hiNormal||observation.concept.hiNormal,
@@ -72,12 +72,12 @@
             <show-observation  show-details-button="::showDetailsButton" ng-if="::!observation.isFormElement()" ng-repeat="member in observation.groupMembers"
                           observation="::member" patient="::patient" show-date="::showDate" show-time="::showTime"
                           config-is-observation-for-images="::configIsObservationForImages"
-                          ng-class="{'video-concept-show': member.isVideoConcept()}"></show-observation>
+                          ng-class="{'video-concept-show': member.isVideoConcept()}" display-name-type="::displayNameType"></show-observation>
         </ul>
     </div>
     <ul ng-if="::(!observation.isFormElement() && print && !observation.isConceptClassConceptDetails())" class="visible-print">
         <show-observation show-details-button="showDetailsButton" ng-if="::!observation.isFormElement()" ng-repeat="member in observation.groupMembers"
                           observation="::member" patient="::patient" show-date="::showDate" show-time="::showTime"
-                          config-is-observation-for-images="::configIsObservationForImages"></show-observation>
+                          config-is-observation-for-images="::configIsObservationForImages" display-name-type="::displayNameType"></show-observation>
     </ul>
  </li>


### PR DESCRIPTION
Configuration support in Obs display control ("displayNameType"), so that the concept name labels can be shown in FSN. If nothing specified default behavior of showing in SN (or FSN in SN is not available) is retained.
For example: 

 `
"basicVitals": {
        "translationKey": "XYZ",
        "type": "observation",
        "isObservation": true,
        "displayOrder": 6,
        "dashboardConfig": {
          "conceptNames": [
            "Height (cm)",
            "Weight (kg)",
            "Body mass index",
            "BMI Status"
          ],
          "showDetailsButton": true,
          "numberOfVisits": 3,
          "displayNameType": "FSN"
        },
        "hideEmptyDisplayControl": true
      }
`


This also resolves the bug where in non-implementation locale usage by user (e,g. default locale = en, user locale = french), the obs display control would not show non-matching concept names, even though the API returned the right data.