### PR TITLE
BAH-3501 | Remove extra line breaks in visitTab print

### DIFF
--- a/ui/app/clinical/common/views/visitTabPrint.html
+++ b/ui/app/clinical/common/views/visitTabPrint.html
@@ -10,9 +10,9 @@
                 {{visitTabConfig.getPrintConfigForCurrentTab().title}}
             </h1>
             <div class="clinic-info">
-                <span>{{certificateHeader.name}}</span><br>
-                <span class="address">{{certificateHeader.address}}</span> <br>
-            </div><br>
+                <span>{{certificateHeader.name}}</span>
+                <span class="address">{{certificateHeader.address}}</span>
+            </div>
             <div class="clinic-info">
                 <span> {{visitTabConfig.getPrintConfigForCurrentTab().header}}</span>
             </div>


### PR DESCRIPTION
Removed the unwanted line breaks in visit tab print.

Before:
<img width="548" alt="image" src="https://github.com/Bahmni/openmrs-module-bahmniapps/assets/111413203/09bbe32a-c8d1-4971-8665-9987e39c8bae">


After:
<img width="541" alt="image" src="https://github.com/Bahmni/openmrs-module-bahmniapps/assets/111413203/8ffea8d6-e8aa-44d3-b72e-f86e2500cc60">
