### PR TITLE
BAH-3502 | Refactor. Add a configuration property to hide provider name

### DIFF
--- a/ui/app/clinical/common/views/visitTabPrint.html
+++ b/ui/app/clinical/common/views/visitTabPrint.html
@@ -19,6 +19,6 @@
         </div>
         <div ng-include="currentVisitUrl"></div>
     </div>
-    <div class="provider-info">{{provider[0].name}}</div>
+    <div ng-if="visitTabConfig.getPrintConfigForCurrentTab().hideProviderNane" class="provider-info">{{provider[0].name}}</div>
 </body>
 </html>


### PR DESCRIPTION
This PR adds a config property to hide provider name in print pdf. The property `hideProviderName` will be added to printing section of each tab in visit.json file.

Example:
openmrs/apps/clinical/visit.json
```
"printing": {
            "title": "Bahmni",
            "header": "Discharge Summary",
            "logo": "../images/bahmniLogo.png",
            "hideProviderName": true
        },
```