### PR TITLE
BAH-3519 | Fix. filled values not shown for Vitals and refactored displaying of chief complaint

### DIFF
--- a/ui/app/common/obs/models/observation.js
+++ b/ui/app/common/obs/models/observation.js
@@ -94,11 +94,40 @@ Bahmni.Common.Obs.Observation = (function () {
             }
 
             if (this.isConceptNameChiefComplaintData()) {
-                if (this.groupMembers[0].value.name !== this.translate.instant("CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_KEY")) {
-                    return this.translate.instant("CHIEF_COMPLAINT_DATA_WITHOUT_OTHER_CONCEPT_TEMPLATE_KEY", {chiefComplaint: this.groupMembers[0].value.name, duration: this.groupMembers[1].value, unit: this.groupMembers[2].value.name});
-                } else {
-                    return this.translate.instant("CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_TEMPLATE_KEY", {chiefComplaint: this.groupMembers[0].value.name, chiefComplaintText: this.groupMembers[1].value, duration: this.groupMembers[2].value, unit: this.groupMembers[3].value.name});
+                var chiefComplaint = null;
+                var chiefComplaintText = null;
+                var duration = null;
+                var unit = null;
+
+                this.groupMembers.forEach(function (obs) {
+                    if (obs.type === "Numeric") {
+                        duration = obs.value;
+                    } else if (obs.concept.name === this.translate.instant("CHIEF_COMPLAINT_DURATION_UNIT_KEY")) {
+                        unit = obs.value.name;
+                    } else {
+                        if (obs.type === "Text") {
+                            chiefComplaintText = obs.value;
+                        }
+                        else {
+                            chiefComplaint = obs.value.name;
+                        }
+                    }
+                }.bind(this));
+
+                if (chiefComplaint === this.translate.instant("CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_KEY")) {
+                    return this.translate.instant("CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_TEMPLATE_KEY", {
+                        chiefComplaint: chiefComplaint,
+                        chiefComplaintText: chiefComplaintText,
+                        duration: duration,
+                        unit: unit
+                    });
                 }
+
+                return this.translate.instant("CHIEF_COMPLAINT_DATA_WITHOUT_OTHER_CONCEPT_TEMPLATE_KEY", {
+                    chiefComplaint: chiefComplaint || chiefComplaintText,
+                    duration: duration,
+                    unit: unit
+                });
             }
 
             value = this.value;

--- a/ui/app/common/obs/views/showObservation.html
+++ b/ui/app/common/obs/views/showObservation.html
@@ -68,14 +68,14 @@
         </div>
     </div>
     <div>
-        <ul ng-if="::(!observation.isFormElement() && !print && !observation.isConceptClassConceptDetails())" class="hidden-print">
+        <ul ng-if="::(!observation.isFormElement() && !print && !observation.isConceptNameChiefComplaintData())" class="hidden-print">
             <show-observation  show-details-button="::showDetailsButton" ng-if="::!observation.isFormElement()" ng-repeat="member in observation.groupMembers"
                           observation="::member" patient="::patient" show-date="::showDate" show-time="::showTime"
                           config-is-observation-for-images="::configIsObservationForImages"
                           ng-class="{'video-concept-show': member.isVideoConcept()}" display-name-type="::displayNameType"></show-observation>
         </ul>
     </div>
-    <ul ng-if="::(!observation.isFormElement() && print && !observation.isConceptClassConceptDetails())" class="visible-print">
+    <ul ng-if="::(!observation.isFormElement() && print && !observation.isConceptNameChiefComplaintData())" class="visible-print">
         <show-observation show-details-button="showDetailsButton" ng-if="::!observation.isFormElement()" ng-repeat="member in observation.groupMembers"
                           observation="::member" patient="::patient" show-date="::showDate" show-time="::showTime"
                           config-is-observation-for-images="::configIsObservationForImages" display-name-type="::displayNameType"></show-observation>

--- a/ui/test/unit/common/obs/observation.spec.js
+++ b/ui/test/unit/common/obs/observation.spec.js
@@ -15,6 +15,9 @@ describe("Observation", function () {
             case "CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_TEMPLATE_KEY":
                 translatedValues = `${chiefComplaint} (${chiefComplaintText}) since ${duration} ${unit}`;
                 break;
+            case "CHIEF_COMPLAINT_DURATION_UNIT_KEY":
+                translatedValues = 'Chief Complaint Duration';
+                break;
             case "CHIEF_COMPLAINT_DATA_WITHOUT_OTHER_CONCEPT_TEMPLATE_KEY":
                 translatedValues = `${chiefComplaint} since ${duration} ${unit}`;
         }
@@ -51,8 +54,8 @@ describe("Observation", function () {
         });
 
         it("should return duration for an observation having multiple groupMembers and not null formspace", function () {
-            var observation = new Observation({"type": "Numeric", "formNamespace": "TestNameSpace", "groupMembers": [{"value": {"name": "Test"}}, {"value": "5"}, {"value": {"name": "weeks"}}], concept: {conceptClass: 'Text', name: "Chief Complaint Data"}}, null, mockTranslateService);
-            var observationWithOtherGeneric = new Observation({"type": "Numeric", "formNamespace": "TestNameSpace", "groupMembers": [{"value": {"name": "Other generic"}}, {"value": "Test"}, {"value": "5"}, {"value": {"name": "weeks"}}], concept: {conceptClass: 'Text', name: "Chief Complaint Data"}}, null, mockTranslateService);
+            var observation = new Observation({"type": "Numeric", "formNamespace": "TestNameSpace", "groupMembers": [{"concept" : {"name" : null}, "value": {"name": "Test"}}, {"type": "Numeric", "value": "5"}, {"concept": {"name": "Chief Complaint Duration"}, "value": { "name": "weeks"}}], concept: {conceptClass: 'Text', name: "Chief Complaint Data"}}, null, mockTranslateService);
+            var observationWithOtherGeneric = new Observation({"type": "Numeric", "formNamespace": "TestNameSpace", "groupMembers": [{"concept" : {"name" : null}, "value": {"name": "Other generic"}}, {"type": "Text", "concept" : {"name" : null}, "value": "Test"}, {"type": "Numeric", "value": "5"}, {"concept": {"name" : "Chief Complaint Duration"}, "value": {"name": "weeks"}}], concept: {conceptClass: 'Text', name: "Chief Complaint Data"}}, null, mockTranslateService);
             expect(observation.getDisplayValue()).toBe("Test since 5 weeks");
             expect(observationWithOtherGeneric.getDisplayValue()).toBe("Other generic (Test) since 5 weeks");
         });


### PR DESCRIPTION
1. Filled values were not shown for vitals form created in form2
2. Refactored displaying of chief complaint by adding initial values and boundary condition 