### PR TITLE
BAH-3531 | Refactor. Show latest patient document uploads first

### DIFF
--- a/ui/app/clinical/common/mappers/patientFileObservationsMapper.js
+++ b/ui/app/clinical/common/mappers/patientFileObservationsMapper.js
@@ -27,8 +27,8 @@ Bahmni.Clinical.PatientFileObservationsMapper = function () {
         });
         patientFileRecords.sort(function (record1, record2) {
             return record1.imageObservation.observationDateTime !== record2.imageObservation.observationDateTime ?
-            DateUtil.parse(record1.imageObservation.observationDateTime) - DateUtil.parse(record2.imageObservation.observationDateTime) :
-            record1.id - record2.id;
+            DateUtil.parse(record2.imageObservation.observationDateTime) - DateUtil.parse(record1.imageObservation.observationDateTime) :
+            record2.id - record2.id;
         });
         return patientFileRecords;
     };

--- a/ui/app/common/domain/services/encounterService.js
+++ b/ui/app/common/domain/services/encounterService.js
@@ -173,6 +173,7 @@ angular.module('bahmni.common.domain')
                 return $http.get(Bahmni.Common.Constants.encounterUrl, {
                     params: {
                         patient: patientUuid,
+                        order: "desc",
                         encounterType: encounterTypeUuid,
                         v: "custom:(uuid,provider,visit:(uuid,startDatetime,stopDatetime),obs:(uuid,concept:(uuid,name),groupMembers:(id,uuid,obsDatetime,value,comment)))"
                     },

--- a/ui/test/unit/clinical/mappers/patientFileObservationsMapper.spec.js
+++ b/ui/test/unit/clinical/mappers/patientFileObservationsMapper.spec.js
@@ -69,11 +69,11 @@ describe("PatientFileObservationsMapper", function () {
         var patientFileRecords = new Bahmni.Clinical.PatientFileObservationsMapper().map(encounters);
 
         expect(patientFileRecords.length).toBe(2);
-        expect(patientFileRecords[0].imageObservation.value).toBe("document-3.jpeg");
-        expect(patientFileRecords[1].imageObservation.value).toBe("document-4.jpeg");
+        expect(patientFileRecords[0].imageObservation.value).toBe("document-4.jpeg");
+        expect(patientFileRecords[1].imageObservation.value).toBe("document-3.jpeg");
         expect(patientFileRecords[0].concept.name).toBe(observationConceptName);
         expect(patientFileRecords[1].concept.name).toBe(observationConceptName);
-        expect(patientFileRecords[0].comment).toBe("something went wrong again");
-        expect(patientFileRecords[1].comment).toBe("something went wrong");
+        expect(patientFileRecords[0].comment).toBe("something went wrong");
+        expect(patientFileRecords[1].comment).toBe("something went wrong again");
     })
 });

--- a/ui/test/unit/registration/services/encounterService.spec.js
+++ b/ui/test/unit/registration/services/encounterService.spec.js
@@ -228,6 +228,7 @@ describe('EncounterService', function () {
         var requestParams = {
             params: {
                 patient: patientUuid,
+                order: "desc",
                 encounterType: encounterTypeUuid,
                 v: "custom:(uuid,provider,visit:(uuid,startDatetime,stopDatetime),obs:(uuid,concept:(uuid,name),groupMembers:(id,uuid,obsDatetime,value,comment)))"
             },


### PR DESCRIPTION
As part of this PR, the patient documents widget is updated to show the document uploads of a patient in reverse chronological order.

This is achieved by passing the `order:desc` parameter to the `/openmrs/ws/rest/v1/encounter` GET api call.