### PR TITLE
BAH-3523 | Add. Pacs Orders and Radiology in Visit Summary Screen

### DIFF
--- a/ui/app/clinical/common/views/visitSummary.html
+++ b/ui/app/clinical/common/views/visitSummary.html
@@ -74,6 +74,13 @@
                             params="::section.config"></investigation-results>
                 </div>
             </div>
+            <div data-ng-switch-when="radiology">
+                <div id="Radiology" ng-if="::section.config"
+                         class="dashboard-radiology-section">
+                    <bm-documents patient="::patient" config="::section.config"
+                                  encounter-type="'RADIOLOGY'"></bm-documents>
+                </div>
+            </div>
             <div data-ng-switch-when="patientFiles" class="section">
                 <div id="Patient-Files" ng-if="section.config && !isBeingPrinted" class="dashboard-radiology-section">
                     <bm-documents patient="::patient" config="::section.config"
@@ -119,6 +126,16 @@
                                                 config="::section.config"
                                                 visit-summary="visitSummary"></custom-display-control>
                     </div>
+                </section>
+            </div>
+            <div data-ng-switch-when="pacsOrders">
+                <section ng-if="::section.config" class="block dashboard-section">
+                    <pacs-orders patient="patient"
+                                 order-type="section.config.orderType"
+                                 visit-uuid="::visitUuid"
+                                 section="section"
+                                 config="::section.config">
+                    </pacs-orders>
                 </section>
             </div>
             <div data-ng-switch-when="conditionsList" class="section">


### PR DESCRIPTION
JIRA -> [BAH-3523](https://bahmni.atlassian.net/browse/BAH-3523)

In this PR, we have reintroduced support for pacsOrder and radiology in the visit summary screen which was removed to align with the requirements of Bahmni Lite, which does not have PACS/radiology order configured. 