### PR TITLE
BAH-3531 | Fix. Sort weight calculation for patient files with same Obsdatetime

### DIFF
--- a/ui/app/clinical/common/mappers/patientFileObservationsMapper.js
+++ b/ui/app/clinical/common/mappers/patientFileObservationsMapper.js
@@ -28,7 +28,7 @@ Bahmni.Clinical.PatientFileObservationsMapper = function () {
         patientFileRecords.sort(function (record1, record2) {
             return record1.imageObservation.observationDateTime !== record2.imageObservation.observationDateTime ?
             DateUtil.parse(record2.imageObservation.observationDateTime) - DateUtil.parse(record1.imageObservation.observationDateTime) :
-            record2.id - record2.id;
+            record2.id - record1.id;
         });
         return patientFileRecords;
     };


### PR DESCRIPTION
This PR fixes the sort order for patient document files with the same obs datetime. This is a patch PR for https://github.com/Bahmni/openmrs-module-bahmniapps/pull/836