### PR TITLE
BAH-3532 | Refactor. Rename hideVisitDate -> hideResultsColumn

### DIFF
--- a/ui/app/clinical/config/visitMandatoryTab.json
+++ b/ui/app/clinical/config/visitMandatoryTab.json
@@ -73,7 +73,7 @@
                 "showAccessionNotes": true,
                 "numberOfVisits": 10,
                 "showDetailsButton": false,
-                "hideVisitDate": true
+                "hideResultsColumn": false
             }
         },
         "Treatments": {

--- a/ui/app/clinical/displaycontrols/investigationresults/views/investigationChart.html
+++ b/ui/app/clinical/displaycontrols/investigationresults/views/investigationChart.html
@@ -8,7 +8,7 @@
                 <p class="placeholder-text">{{'NO_LAB_ORDERS_FOR_PATIENT_MESSAGE_KEY' | translate}}</p>
             </div>
             <table class="investigation-chart" bindonce="accessions">
-                <thead ng-if="::!params.hideVisitDate">
+                <thead ng-if="::!params.hideResultsColumn">
                     <tr>
                         <th nowrap>&nbsp;</th>
                         <td nowrap ng-repeat="dateLabel in accessions.getDateLabels()">{{::dateLabel.date | bahmniDate}}</td>
@@ -25,7 +25,7 @@
                         </td>
                         <td ng-repeat="dateLabel in accessions.getDateLabels()"
                             ng-class="::{'has-uploaded-file': accessions.hasUploadedFiles(dateLabel, testOrderLabel)}"
-                            ng-if="::!params.hideVisitDate">
+                            ng-if="::!params.hideResultsColumn">
                             <span ng-init="results = accessions.getResult(dateLabel, testOrderLabel)">
                                 <span bm-pop-over autoclose="true" class="test-result" ng-repeat="res in results">
                                     <span ng-class="::{'referred-out': res.referredOut}">


### PR DESCRIPTION
JIRA -> [BAH-3532](https://bahmni.atlassian.net/browse/BAH-3532)

This PR renames the `hideVisitDate` control to `hideResultsColumn` for improved clarity. The `hideResultsColumn` control is responsible for concealing the display of lab order results.

hideResultsColumn : true           |  hideResultsColumn : false
:-------------------------:|:-------------------------:
![](https://github.com/Bahmni/openmrs-module-bahmniapps/assets/121226043/15dbd139-d70a-4708-8ea3-f0245f9b0125)  |  ![](https://github.com/Bahmni/openmrs-module-bahmniapps/assets/121226043/998e3636-42db-4b2a-85a4-2de7d2b68cc3)