### PR TITLE
Fix css for zscore lengthy text in registration 2nd page

### DIFF
--- a/ui/app/styles/registration/_registration.scss
+++ b/ui/app/styles/registration/_registration.scss
@@ -163,6 +163,10 @@ body {
         .form-field {
             padding: 0;
             border-bottom: 0;
+            .value-text-only {
+                display: inline-block;
+                width: 60%;
+            }
         }
 
         &.hierarchy {


### PR DESCRIPTION
In registration second page: The lengthy Z Score comment text is fixed.

Asana Link: https://app.asana.com/0/1204322126657135/1205585485493098/f