### PR TITLE
BAH-3606 | Add. Panel Based Grouping Of Tests In Investigation Chart View

### DIFF
--- a/ui/app/clinical/displaycontrols/investigationresults/directives/investigationResults.js
+++ b/ui/app/clinical/displaycontrols/investigationresults/directives/investigationResults.js
@@ -17,8 +17,8 @@ angular.module('bahmni.clinical')
                 visitUuids: $scope.params.visitUuids,
                 initialAccessionCount: $scope.params.initialAccessionCount,
                 latestAccessionCount: $scope.params.latestAccessionCount,
-                sortLabOrdersByName: $scope.params.chartConfig.sortLabOrdersByName,
-                sortResultColumnsLatestFirst: $scope.params.chartConfig.sortResultColumnsLatestFirst
+                sortResultColumnsLatestFirst: $scope.params.chartConfig.sortResultColumnsLatestFirst,
+                groupOrdersByPanel: $scope.params.chartConfig.groupByPanel
             };
             $scope.initialization = labOrderResultService.getAllForPatient(params)
                 .then(function (results) {

--- a/ui/app/clinical/displaycontrols/investigationresults/models/tabularLabOrderResults.js
+++ b/ui/app/clinical/displaycontrols/investigationresults/models/tabularLabOrderResults.js
@@ -1,7 +1,7 @@
 'use strict';
 
 Bahmni.Clinical.TabularLabOrderResults = (function () {
-    var TabularLabOrderResults = function (tabularResult, accessionConfig, sortLabOrdersByName, sortResultColumnsLatestFirst) {
+    var TabularLabOrderResults = function (tabularResult, accessionConfig, sortResultColumnsLatestFirst) {
         var self = this;
         this.tabularResult = tabularResult;
 
@@ -50,11 +50,6 @@ Bahmni.Clinical.TabularLabOrderResults = (function () {
 
         this.getTestOrderLabels = function () {
             var orders = this.tabularResult.orders;
-            if (sortLabOrdersByName) {
-                orders.sort(function (a, b) {
-                    return a.testName.localeCompare(b.testName);
-                });
-            }
             return orders;
         };
 

--- a/ui/app/clinical/displaycontrols/investigationresults/services/labOrderResultService.js
+++ b/ui/app/clinical/displaycontrols/investigationresults/services/labOrderResultService.js
@@ -13,11 +13,10 @@ angular.module('bahmni.clinical')
             });
         };
 
-        var groupByPanel = function (accessions) {
-            var grouped = [];
-            accessions.forEach(function (labOrders) {
-                var panels = {};
-                var accessionGroup = [];
+        var groupLabOrdersByPanel = function (labOrders) {
+            var panels = {};
+            var accessionGroup = [];
+            if (labOrders) {
                 labOrders.forEach(function (labOrder) {
                     if (!labOrder.panelName) {
                         labOrder.isPanel = false;
@@ -33,10 +32,17 @@ angular.module('bahmni.clinical')
                         panels[labOrder.panelName].tests.push(labOrder);
                     }
                 });
-                _.values(panels).forEach(function (val) {
-                    accessionGroup.push(val);
-                });
-                grouped.push(accessionGroup);
+            }
+            _.values(panels).forEach(function (value) {
+                accessionGroup.push(value);
+            });
+            return accessionGroup;
+        };
+
+        var groupByPanel = function (accessions) {
+            var grouped = [];
+            accessions.forEach(function (labOrders) {
+                grouped.push(groupLabOrdersByPanel(labOrders));
             });
             return grouped;
         };
@@ -53,7 +59,16 @@ angular.module('bahmni.clinical')
             );
         };
 
-        var transformGroupSort = function (results, initialAccessionCount, latestAccessionCount, sortLabOrdersByName, sortResultColumnsLatestFirst) {
+        var flattenedTabularData = function (results) {
+            var flattenedResults = _(results).map(
+                function (result) {
+                    return result.isPanel === true ? [result, result.tests] : result;
+                }
+            ).flattenDeep().value();
+            return flattenedResults;
+        };
+
+        var transformGroupSort = function (results, initialAccessionCount, latestAccessionCount, sortResultColumnsLatestFirst, groupOrdersByPanel) {
             var labOrderResults = results.results;
             sanitizeData(labOrderResults);
 
@@ -62,7 +77,10 @@ angular.module('bahmni.clinical')
                 latestAccessionCount: latestAccessionCount
             };
 
-            var tabularResult = new Bahmni.Clinical.TabularLabOrderResults(results.tabularResult, accessionConfig, sortLabOrdersByName, sortResultColumnsLatestFirst);
+            var tabularResult = new Bahmni.Clinical.TabularLabOrderResults(results.tabularResult, accessionConfig, sortResultColumnsLatestFirst);
+            if (groupOrdersByPanel) {
+                tabularResult.tabularResult.orders = groupLabOrdersByPanel(tabularResult.tabularResult.orders);
+            }
             var accessions = _.groupBy(labOrderResults, function (labOrderResult) {
                 return labOrderResult.accessionUuid;
             });
@@ -102,13 +120,16 @@ angular.module('bahmni.clinical')
                 params: paramsToBeSent,
                 withCredentials: true
             }).then(function (response) {
-                var results = transformGroupSort(response.data, params.initialAccessionCount, params.latestAccessionCount, params.sortLabOrdersByName, params.sortResultColumnsLatestFirst);
+                var results = transformGroupSort(response.data, params.initialAccessionCount, params.latestAccessionCount, params.sortResultColumnsLatestFirst, params.groupOrdersByPanel);
                 var sortedConceptSet = new Bahmni.Clinical.ConceptWeightBasedSorter(allTestsAndPanelsConcept);
+                results.tabularResult.tabularResult.orders = sortedConceptSet.sortTestResults(results.tabularResult.tabularResult.orders);
                 var resultObject = {
                     labAccessions: flattened(results.accessions.map(sortedConceptSet.sortTestResults)),
                     tabular: results.tabularResult
                 };
-                resultObject.tabular.tabularResult.orders = sortedConceptSet.sortTestResults(resultObject.tabular.tabularResult.orders);
+                if (params.groupOrdersByPanel) {
+                    resultObject.tabular.tabularResult.orders = flattenedTabularData(resultObject.tabular.tabularResult.orders);
+                }
                 deferred.resolve(resultObject);
             });
 

--- a/ui/app/clinical/displaycontrols/investigationresults/views/investigationChart.html
+++ b/ui/app/clinical/displaycontrols/investigationresults/views/investigationChart.html
@@ -17,7 +17,7 @@
                 <tbody>
                     <tr ng-repeat="testOrderLabel in accessions.getTestOrderLabels()">
                         <td class="normal fixed-column">
-                            <span ng-if="!testOrderLabel.isPanel" bo-text="testOrderLabel.testName" ng-style="{'padding-left': testOrderLabel.panelName ? '20px' : ''}"></span>
+                            <span ng-if="!testOrderLabel.isPanel" bo-text="testOrderLabel.testName" ng-style="{'padding-left': params.chartConfig.groupByPanel && testOrderLabel.panelName ? '20px' : ''}"></span>
                             <span ng-if="testOrderLabel.isPanel" bo-text="testOrderLabel.orderName" class="labPanel"></span>
                             <span ng-show="::accessions.hasRange(testOrderLabel)" class="range">
                                 <span bo-text="'(' + testOrderLabel.minNormal + ' - ' + testOrderLabel.maxNormal + ')'"></span>

--- a/ui/app/clinical/displaycontrols/investigationresults/views/investigationChart.html
+++ b/ui/app/clinical/displaycontrols/investigationresults/views/investigationChart.html
@@ -17,7 +17,8 @@
                 <tbody>
                     <tr ng-repeat="testOrderLabel in accessions.getTestOrderLabels()">
                         <td class="normal fixed-column">
-                            <span bo-text="testOrderLabel.testName"></span>
+                            <span ng-if="!testOrderLabel.isPanel" bo-text="testOrderLabel.testName" ng-style="{'padding-left': testOrderLabel.panelName ? '20px' : ''}"></span>
+                            <span ng-if="testOrderLabel.isPanel" bo-text="testOrderLabel.orderName" class="labPanel"></span>
                             <span ng-show="::accessions.hasRange(testOrderLabel)" class="range">
                                 <span bo-text="'(' + testOrderLabel.minNormal + ' - ' + testOrderLabel.maxNormal + ')'"></span>
                             </span>

--- a/ui/app/clinical/displaycontrols/investigationresults/views/investigationTableRow.html
+++ b/ui/app/clinical/displaycontrols/investigationresults/views/investigationTableRow.html
@@ -4,7 +4,7 @@
 
 <tr bo-if="!test.isPanel" ng-class="{'test-notes-parent': test.notes, 'notes-open': test.showDetails}">
     <td class="testUnderPanel" bo-class="{'has-uploaded-file': test.uploadedFileName}">
-        <span ng-if="!test.uploadedFileName" bo-text="::getLocaleSpecificNameForTest(test)"></span>
+        <span ng-if="!test.uploadedFileName" bo-text="::getLocaleSpecificNameForTest(test)" ng-style="{'padding-left': test.panelName ? '20px' : ''}"></span>
         <span ng-if="test.labReportUrl">
             <a  href="{{test.labReportUrl}}" stop-event-propagation="click" target="_blank">{{::getLocaleSpecificNameForTest(test)}}
             </a>

--- a/ui/app/styles/clinical/_visit.scss
+++ b/ui/app/styles/clinical/_visit.scss
@@ -497,6 +497,7 @@ span.range {
 
 span.labPanel {
     font-weight: bold;
+    font-family: Helvetica,sans-serif !important;
 }
 
 .laborder-section {

--- a/ui/app/styles/clinical/_visit.scss
+++ b/ui/app/styles/clinical/_visit.scss
@@ -495,6 +495,10 @@ span.range {
     }
 }
 
+span.labPanel {
+    font-weight: bold;
+}
+
 .laborder-section {
     table {
         margin-bottom: 10px;

--- a/ui/test/unit/clinical/services/labOrderResultService.spec.js
+++ b/ui/test/unit/clinical/services/labOrderResultService.spec.js
@@ -16,11 +16,16 @@ describe("labOrderResultService", function() {
             {"accessionUuid": "uuid1", "accessionDateTime":1401437955000, "testName": "Haemoglobin", "panelName": "Routine Blood"},
             {"accessionUuid": "uuid1", "accessionDateTime":1401437955000, "testName": "ESR", "panelName": "Routine Blood"},
             {"accessionUuid": "uuid2", "accessionDateTime":1401437956000, "testName": "ZN Stain(Sputum)"},
-        ], "tabularResult": {
+        ], 
+        "tabularResult": {
             "values":[
                 {"testOrderIndex":0,"dateIndex":0,"abnormal":false,"result":"25.0"},
+                {"testOrderIndex":1,"dateIndex":0,"abnormal":false,"result":"55.0"},
+                {"testOrderIndex":2,"dateIndex":0,"abnormal":false,"result":"85.0"}
             ], "orders":[
-                {"minNormal":0.0,"maxNormal":6.0,"testName":"ZN Stain(Sputum)","testUnitOfMeasurement":"%","index":0}
+                {"minNormal":0.0,"maxNormal":6.0,"testName":"ZN Stain(Sputum)","testUnitOfMeasurement":"%","index":0, "panelName": "Routine Blood"},
+                {"minNormal":0.0,"maxNormal":6.0,"testName":"CD4 Test","testUnitOfMeasurement":"%","index":1},
+                {"minNormal":0.0,"maxNormal":6.0,"testName":"Platelets","testUnitOfMeasurement":"%","index":2, "panelName": "Routine Blood"}
             ], "dates":[
                 {"index":0,"date":"30-May-2014"}
             ]
@@ -49,7 +54,8 @@ describe("labOrderResultService", function() {
     describe("getAllForPatient", function(){
         var params = {
             patientUuid: "123",
-            numberOfVisits: 1
+            numberOfVisits: 1,
+            groupOrdersByPanel: true
         };
 
         it("should fetch all Lab orders & results and group by accessions", function(done){
@@ -61,6 +67,7 @@ describe("labOrderResultService", function() {
                 done();
             });
         });
+
         it("should sort by accession date and group by panel", function(done){
             labOrderResultService.getAllForPatient(params).then(function(results) {
                 expect(mockHttp.get.calls.mostRecent().args[1].params.patientUuid).toBe("123");
@@ -80,6 +87,16 @@ describe("labOrderResultService", function() {
                 expect(results.labAccessions[1][2].isPanel).toBeTruthy();
                 expect(results.labAccessions[1][2].orderName).toBe("Routine Blood");
                 expect(results.labAccessions[1][2].tests.length).toBe(2);
+                done();
+            });
+        });
+
+        it("should group tabularResult by panel", function(done){
+            labOrderResultService.getAllForPatient(params).then(function(results) {
+                expect(mockHttp.get.calls.mostRecent().args[1].params.patientUuid).toBe("123");
+
+                expect(results.tabular.tabularResult.orders[0].isPanel).toBeFalsy();
+                expect(results.tabular.tabularResult.orders[1].tests.length).toBe(2);
                 done();
             });
         });

--- a/ui/test/unit/clinical/services/labOrderResultService.spec.js
+++ b/ui/test/unit/clinical/services/labOrderResultService.spec.js
@@ -19,15 +19,15 @@ describe("labOrderResultService", function() {
         ], 
         "tabularResult": {
             "values":[
-                {"testOrderIndex":0,"dateIndex":0,"abnormal":false,"result":"25.0"},
-                {"testOrderIndex":1,"dateIndex":0,"abnormal":false,"result":"55.0"},
-                {"testOrderIndex":2,"dateIndex":0,"abnormal":false,"result":"85.0"}
+                {"testOrderIndex": 0, "dateIndex": 0, "abnormal": false, "result": "25.0"},
+                {"testOrderIndex": 1, "dateIndex": 0, "abnormal": false, "result": "55.0"},
+                {"testOrderIndex": 2, "dateIndex": 0, "abnormal": false, "result": "85.0"}
             ], "orders":[
-                {"minNormal":0.0,"maxNormal":6.0,"testName":"ZN Stain(Sputum)","testUnitOfMeasurement":"%","index":0, "panelName": "Routine Blood"},
-                {"minNormal":0.0,"maxNormal":6.0,"testName":"CD4 Test","testUnitOfMeasurement":"%","index":1},
-                {"minNormal":0.0,"maxNormal":6.0,"testName":"Platelets","testUnitOfMeasurement":"%","index":2, "panelName": "Routine Blood"}
+                {"index":0, "minNormal": 0.0, "maxNormal": 0.0, "testName": "ZN Stain(Sputum)", "testUnitOfMeasurement":"%", "panelName": "Routine Blood"},
+                {"index":1, "minNormal": 0.0, "maxNormal": 0.0, "testName": "CD4 Test", "testUnitOfMeasurement":"%"},
+                {"index":2, "minNormal": 0.0, "maxNormal": 0.0, "testName": "Platelets", "testUnitOfMeasurement":"%", "panelName": "Routine Blood"}
             ], "dates":[
-                {"index":0,"date":"30-May-2014"}
+                {"index":0, "date": "30-May-2014"}
             ]
         }
     };
@@ -58,6 +58,19 @@ describe("labOrderResultService", function() {
             groupOrdersByPanel: true
         };
 
+        it("should group tabularResult by panel", function(done){
+            labOrderResultService.getAllForPatient(params).then(function(results) {
+                expect(mockHttp.get.calls.mostRecent().args[1].params.patientUuid).toBe("123");
+
+                expect(results.tabular.tabularResult.orders[0].isPanel).toBeFalsy();
+                expect(results.tabular.tabularResult.orders[0].orderName).toBe("CD4 Test");
+                expect(results.tabular.tabularResult.orders[1].isPanel).toBeTruthy();
+                expect(results.tabular.tabularResult.orders[1].orderName).toBe("Routine Blood");
+                expect(results.tabular.tabularResult.orders[1].tests.length).toBe(2);
+                done();
+            });
+        });
+        
         it("should fetch all Lab orders & results and group by accessions", function(done){
             labOrderResultService.getAllForPatient(params).then(function(results) {
                 expect(mockHttp.get.calls.mostRecent().args[1].params.patientUuid).toBe("123");
@@ -91,14 +104,5 @@ describe("labOrderResultService", function() {
             });
         });
 
-        it("should group tabularResult by panel", function(done){
-            labOrderResultService.getAllForPatient(params).then(function(results) {
-                expect(mockHttp.get.calls.mostRecent().args[1].params.patientUuid).toBe("123");
-
-                expect(results.tabular.tabularResult.orders[0].isPanel).toBeFalsy();
-                expect(results.tabular.tabularResult.orders[1].tests.length).toBe(2);
-                done();
-            });
-        });
     });
 });


### PR DESCRIPTION
JIRA -> [BAH-3606](https://bahmni.atlassian.net/browse/BAH-3606)

In this PR, I have added a configuration to  group tests by panels and to display it in the investigation chart view. Also, removed the logic for sorting lab test by name since we decided to go with sorting based on sortWeight, it is no longer needed.