### PR TITLE
Deepthi M|BAH-3581| Fixed the issue with Identifier being loaded on the print Header in docker standard env.

### DIFF
--- a/ui/app/clinical/dashboard/controllers/patientDashboardTreatmentController.js
+++ b/ui/app/clinical/dashboard/controllers/patientDashboardTreatmentController.js
@@ -9,7 +9,11 @@ angular.module('bahmni.clinical')
             var sharePrescriptionToggles = {"prescriptionEmailToggle": $rootScope.prescriptionEmailToggle};
             var printParams = treatmentConfigParams.prescriptionPrint || {};
             printParams.locationName = $rootScope.facilityLocation.name;
-            printParams.locationAddress = $rootScope.facilityLocation.attributes[0] ? $rootScope.facilityLocation.attributes[0].display.split(":")[1].trim() : null;
+
+            const printHeaderAttributes = $rootScope.facilityLocation.attributes.filter(function (attribute) {
+                return attribute.display.includes('Print Header') && !attribute.voided;
+            });
+            printParams.locationAddress = printHeaderAttributes[0] ? printHeaderAttributes[0].display.split(":")[1].trim() : null;
 
             $scope.dashboardConfig = {};
             $scope.expandedViewConfig = {};
@@ -39,3 +43,4 @@ angular.module('bahmni.clinical')
 
             $scope.$on("$destroy", cleanUpListener);
         }]);
+


### PR DESCRIPTION
In docker standard environment prescription print header is showing IdentifierSourceName in print Header instead of referring to PrintHeader.This works fine in docker lite environment as we do not have as we do not have IdentifierSourceName attribute in locations in lite environment it always refers to print header properly.