### PR TITLE
BAH-3644 | Add. Event Trigger To Publish Image

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -6,7 +6,12 @@ on:
       - 'release-*'
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
-
+  workflow_run:
+    workflows: [Pull Translations from Transifex]
+    types: [completed]
+    branches:
+      - master
+      - 'release-*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
JIRA -> [BAH-3644](https://bahmni.atlassian.net/browse/BAH-3644)

In this PR, an workflow based event trigger has been added to the Build and Publish [openmrs-module-bahmniapps](https://github.com/Bahmni/openmrs-module-bahmniapps) workflow. The Build and Publish openmrs-module-bahmniapps workflow was not getting triggered as the commit action in the Pull Translations From Transifex workflow run can’t trigger a new workflow run [(Refer comment)](https://github.com/orgs/community/discussions/27028#discussioncomment-3254360). The changes added will programmatically trigger Build and Publish openmrs-module-bahmniapps once the Pull Translations From Transifex workflow is successfully completed.