### PR TITLE
Arjun | To hide show/hide IPD button in treatments tab

### DIFF
--- a/ui/app/clinical/consultation/controllers/addTreatmentController.js
+++ b/ui/app/clinical/consultation/controllers/addTreatmentController.js
@@ -19,7 +19,7 @@ angular.module('bahmni.clinical')
             $scope.clearButtonClicked = false;
             $scope.conceptSource = localStorage.getItem("conceptSource") || "";
 
-            $scope.allMedicinesInPrescriptionAvailableForIPD = appService.getAppDescriptor().getConfigValue("allMedicinesInPrescriptionAvailableForIPD");
+            $scope.allMedicinesInPrescriptionAvailableForIPD = appService.getAppDescriptor().getConfigValue("allMedicinesInPrescriptionAvailableForIPD") !== null ? appService.getAppDescriptor().getConfigValue("allMedicinesInPrescriptionAvailableForIPD") : true;
             var currentVisitType;
             if ($scope.allMedicinesInPrescriptionAvailableForIPD) {
                 visitService.search(

--- a/ui/app/clinical/consultation/controllers/addTreatmentController.js
+++ b/ui/app/clinical/consultation/controllers/addTreatmentController.js
@@ -20,7 +20,7 @@ angular.module('bahmni.clinical')
             $scope.conceptSource = localStorage.getItem("conceptSource") || "";
 
             $scope.allMedicinesInPrescriptionAvailableForIPD = appService.getAppDescriptor().getConfigValue("allMedicinesInPrescriptionAvailableForIPD");
-            let currentVisitType;
+            var currentVisitType;
             if ($scope.allMedicinesInPrescriptionAvailableForIPD) {
                 visitService.search(
                     {patient: $state.params.patientUuid, includeInactive: false, v: "custom:(uuid,visitType,startDatetime,stopDatetime,location,encounters:(uuid))"}

--- a/ui/app/clinical/consultation/controllers/drugOrderHistoryController.js
+++ b/ui/app/clinical/consultation/controllers/drugOrderHistoryController.js
@@ -12,11 +12,11 @@ angular.module('bahmni.clinical')
             var prescribedDrugOrders = [];
             $scope.dispensePrivilege = Bahmni.Clinical.Constants.dispensePrivilege;
             $scope.scheduledDate = DateUtil.getDateWithoutTime(DateUtil.addDays(DateUtil.now(), 1));
-            $scope.enableIPDFeature = appService.getAppDescriptor().getConfigValue("enableIPDFeature");
+            $scope.allMedicinesInPrescriptionAvailableForIPD = appService.getAppDescriptor().getConfigValue("allMedicinesInPrescriptionAvailableForIPD");
             $scope.printPrescriptionFeature = appService.getAppDescriptor().getConfigValue("printPrescriptionFeature");
             $scope.selectedDrugs = {};
 
-            if ($scope.enableIPDFeature) {
+            if (!$scope.allMedicinesInPrescriptionAvailableForIPD) {
                 $scope.updateOrderType = function (drugOrder) {
                     var updatedDrugOrder = angular.copy(drugOrder);
                     updatedDrugOrder.careSetting = updatedDrugOrder.careSetting === Bahmni.Clinical.Constants.careSetting.outPatient ? Bahmni.Clinical.Constants.careSetting.inPatient : Bahmni.Clinical.Constants.careSetting.outPatient;
@@ -220,7 +220,7 @@ angular.module('bahmni.clinical')
                 });
             };
 
-            $scope.enableIPDFeature && spinner.forPromise(treatmentService.getMedicationSchedulesForOrders($stateParams.patientUuid, getActiveAndPrescribedDrugOrdersUuids()).then(function (response) {
+            !$scope.allMedicinesInPrescriptionAvailableForIPD && spinner.forPromise(treatmentService.getMedicationSchedulesForOrders($stateParams.patientUuid, getActiveAndPrescribedDrugOrdersUuids()).then(function (response) {
                 $scope.medicationSchedules = response.data;
             }));
 

--- a/ui/app/clinical/consultation/controllers/drugOrderHistoryController.js
+++ b/ui/app/clinical/consultation/controllers/drugOrderHistoryController.js
@@ -12,7 +12,7 @@ angular.module('bahmni.clinical')
             var prescribedDrugOrders = [];
             $scope.dispensePrivilege = Bahmni.Clinical.Constants.dispensePrivilege;
             $scope.scheduledDate = DateUtil.getDateWithoutTime(DateUtil.addDays(DateUtil.now(), 1));
-            $scope.allMedicinesInPrescriptionAvailableForIPD = appService.getAppDescriptor().getConfigValue("allMedicinesInPrescriptionAvailableForIPD");
+            $scope.allMedicinesInPrescriptionAvailableForIPD = appService.getAppDescriptor().getConfigValue("allMedicinesInPrescriptionAvailableForIPD") !== null ? appService.getAppDescriptor().getConfigValue("allMedicinesInPrescriptionAvailableForIPD") : true;
             $scope.printPrescriptionFeature = appService.getAppDescriptor().getConfigValue("printPrescriptionFeature");
             $scope.selectedDrugs = {};
 

--- a/ui/app/clinical/consultation/directives/newDrugOrders.js
+++ b/ui/app/clinical/consultation/directives/newDrugOrders.js
@@ -3,7 +3,7 @@
 angular.module('bahmni.clinical')
     .directive('newDrugOrders', ['messagingService', function (messagingService) {
         var controller = function ($scope, $rootScope, $stateParams, appService, visitService) {
-            $scope.allMedicinesInPrescriptionAvailableForIPD = appService.getAppDescriptor().getConfigValue("allMedicinesInPrescriptionAvailableForIPD");
+            $scope.allMedicinesInPrescriptionAvailableForIPD = appService.getAppDescriptor().getConfigValue("allMedicinesInPrescriptionAvailableForIPD") !== null ? appService.getAppDescriptor().getConfigValue("allMedicinesInPrescriptionAvailableForIPD") : true;
             if (!$scope.allMedicinesInPrescriptionAvailableForIPD) {
                 $rootScope.$on("event:setEncounterId", function (event, encounterId) {
                     $scope.encounterId = encounterId;

--- a/ui/app/clinical/consultation/directives/newDrugOrders.js
+++ b/ui/app/clinical/consultation/directives/newDrugOrders.js
@@ -4,22 +4,6 @@ angular.module('bahmni.clinical')
     .directive('newDrugOrders', ['messagingService', function (messagingService) {
         var controller = function ($scope, $rootScope, $stateParams, appService, visitService) {
             $scope.allMedicinesInPrescriptionAvailableForIPD = appService.getAppDescriptor().getConfigValue("allMedicinesInPrescriptionAvailableForIPD");
-            let currentVisitType;
-            if ($scope.allMedicinesInPrescriptionAvailableForIPD) {
-                visitService.search(
-                    {patient: $stateParams.patientUuid, includeInactive: false, v: "custom:(uuid,visitType,startDatetime,stopDatetime,location,encounters:(uuid))"}
-                ).then(function (response) {
-                    currentVisitType = response.data.results[0].visitType.display;
-                });
-                $scope.$watch('treatments', function (oldValue, newValue) {
-                    if (oldValue !== newValue) {
-                        $scope.treatments.forEach(function (treatment) {
-                            treatment.careSetting = currentVisitType === "IPD" ? Bahmni.Clinical.Constants.careSetting.inPatient : treatment.careSetting;
-                        });
-                    }
-                });
-            }
-            $scope.allMedicinesInPrescriptionAvailableForIPD = appService.getAppDescriptor().getConfigValue("allMedicinesInPrescriptionAvailableForIPD");
             if (!$scope.allMedicinesInPrescriptionAvailableForIPD) {
                 $rootScope.$on("event:setEncounterId", function (event, encounterId) {
                     $scope.encounterId = encounterId;

--- a/ui/app/clinical/consultation/views/newDrugOrders.html
+++ b/ui/app/clinical/consultation/views/newDrugOrders.html
@@ -65,6 +65,10 @@
                      | {{newTreatment.additionalInstructions}}
                 </div>
                 <div ng-if="newTreatment.getQuantityWithUnit()"> | {{newTreatment.getQuantityWithUnit()}}</div>
+                <div>
+                    <span ng-show="allMedicinesInPrescriptionAvailableForIPD && newTreatment.careSetting==='INPATIENT'"> | {{ ::'IPD_BUTTON' | translate}}</span>
+                    <span ng-show="allMedicinesInPrescriptionAvailableForIPD && newTreatment.careSetting==='OUTPATIENT'"> | {{ ::'OPD_BUTTON' | translate}}</span>
+                </div>
             </div>
         </li>
     </ul>

--- a/ui/app/clinical/consultation/views/newDrugOrders.html
+++ b/ui/app/clinical/consultation/views/newDrugOrders.html
@@ -41,7 +41,7 @@
             </div>
             <div class="button-group-wrapper">
                 <div class="button-group">
-                    <button ng-show="enableIPDFeature" class="ipd-btn" ng-click="toggleCareSetting(newTreatment)" ng-disabled="shouldDisableIPDButton(newTreatment)">
+                    <button ng-show="!allMedicinesInPrescriptionAvailableForIPD" class="ipd-btn" ng-click="toggleCareSetting(newTreatment)" ng-disabled="shouldDisableIPDButton(newTreatment)">
                         <i class="fa fa-check" ng-show="newTreatment.careSetting === 'INPATIENT'"></i>
                         {{ ::'IPD_BUTTON' | translate}}
                     </button>

--- a/ui/app/clinical/consultation/views/treatmentSections/drugOrderHistory.html
+++ b/ui/app/clinical/consultation/views/treatmentSections/drugOrderHistory.html
@@ -76,6 +76,10 @@
                                     </div>
                                     <div ng-if="drugOrder.additionalInstructions"> | {{drugOrder.additionalInstructions}}</div>
                                     <div ng-if="drugOrder.getQuantityWithUnit()"> | {{drugOrder.getQuantityWithUnit()}}</div>
+                                    <div>
+                                        <span ng-show="allMedicinesInPrescriptionAvailableForIPD && drugOrder.careSetting==='INPATIENT'"> | {{ ::'IPD_BUTTON' | translate}}</span>
+                                        <span ng-show="allMedicinesInPrescriptionAvailableForIPD && drugOrder.careSetting==='OUTPATIENT'"> | {{ ::'OPD_BUTTON' | translate}}</span>
+                                    </div>
                                     <div class="footer-note">
                                         <span class="time-stamp">
                                             <span class="time">{{drugOrder.dateActivated | bahmniDate}}</span>

--- a/ui/app/clinical/consultation/views/treatmentSections/drugOrderHistory.html
+++ b/ui/app/clinical/consultation/views/treatmentSections/drugOrderHistory.html
@@ -34,7 +34,7 @@
                                 </div>
 								<div class="button-group-wrapper">
                                     <div class="button-group">
-                                        <button ng-show="enableIPDFeature" class="ipd-btn" ng-click="updateOrderType(drugOrder, drugOrderGroup.drugOrders)" ng-disabled="disableIPDButton(drugOrder)">
+                                        <button ng-show="!allMedicinesInPrescriptionAvailableForIPD" class="ipd-btn" ng-click="updateOrderType(drugOrder, drugOrderGroup.drugOrders)" ng-disabled="disableIPDButton(drugOrder)">
                                             <i class="fa fa-check" ng-show="drugOrder.careSetting === 'INPATIENT'"></i>
                                             {{ ::'IPD_BUTTON' | translate}}
                                         </button>

--- a/ui/app/i18n/clinical/locale_en.json
+++ b/ui/app/i18n/clinical/locale_en.json
@@ -104,6 +104,7 @@
   "VISIT_ON_TRANSLATION_KEY": "Visit On",
   "ADD_TO_DRUG_CHART_KEY": "Add to Drug Chart",
   "IPD_BUTTON": "IPD",
+  "OPD_BUTTON": "OPD",
   "ENTERING_DATA_FOR_TRANSLATION_KEY": "Entering data for",
   "EDITITNG_DATA_FOR_ENCOUNTER_TRANSLATION_KEY": "Editing data for encounter",
   "ON_BEHALF_OF_TRANSLATION_KEY": "On behalf of",

--- a/ui/test/unit/clinical/controllers/drugOrderHistoryController.spec.js
+++ b/ui/test/unit/clinical/controllers/drugOrderHistoryController.spec.js
@@ -407,7 +407,7 @@ describe("DrugOrderHistoryControllerIPD", function () {
         appService = jasmine.createSpyObj('appService', ['getAppDescriptor']);
         appService.getAppDescriptor.and.returnValue({
             getConfigValue: function (config) {
-                return true;
+                return false;
             }
         });
         allergyService = jasmine.createSpyObj('allergyService', ['getAllergyForPatient']);


### PR DESCRIPTION
This PR has changes to show or hide IPD button in the treatments display control. Earlier, enableIPDFeature was used as common config to hide IPD button and the IPD dashboard. As part of this change 
- any medication added in an IPD visit will be considered as IPD medication and OPD medication if added in an OPD visit
- A text will be shown in each tile of treatment (already prescribed and new) to indicate whether it is an IPD or OPD medication

# Screenshots

## Medications with `!allMedicinesInPrescriptionAvailableForIPD` set to true
<img width="1435" alt="image" src="https://github.com/Bahmni/openmrs-module-bahmniapps/assets/91885483/bf628b0d-2925-4bca-996b-034714de527a">

## When `!allMedicinesInPrescriptionAvailableForIPD` set to false
<img width="1390" alt="image" src="https://github.com/Bahmni/openmrs-module-bahmniapps/assets/91885483/f5a579dd-9d1b-4033-878b-b8874bcc4562">
