### PR TITLE
BAH-3701 | Package Next-Ui minified CSS in Gruntfile

### DIFF
--- a/ui/Gruntfile.js
+++ b/ui/Gruntfile.js
@@ -22,7 +22,8 @@ module.exports = function (grunt) {
         'components/ng-tags-input/ng-tags-input.min.css',
         'components/jquery-ui/themes/smoothness/jquery-ui.min.css',
         'micro-frontends-dist/shared.min.css',
-        'micro-frontends-dist/ipd.min.css'
+        'micro-frontends-dist/ipd.min.css',
+        'micro-frontends-dist/next-ui.min.css'
     ];
 
     var libraryJSFiles = [


### PR DESCRIPTION
JIRA - https://bahmni.atlassian.net/browse/BAH-3701

The Next-Ui CSS changes were built and packaged in micro-frontend dist folder but was not added to the bahmni-web build. Due to this, CSS for Next-Ui was broken.