### PR TITLE
Fix. Upgrade Ruby Version

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -31,10 +31,10 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
-      - name: Use Ruby 2.5
+      - name: Use Ruby 3.1
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 3.1
       - run: npm install -g bower
       - run: npm install -g grunt-cli
       - run: gem install compass

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -1,7 +1,7 @@
 name: Validate PR
 
 on:
- pull_request:
+  pull_request:
     branches: [ master ]
 
 jobs:
@@ -13,10 +13,10 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
-      - name: Use Ruby 2.5
+      - name: Use Ruby 3.1
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 3.1
       - run: npm install -g bower 
       - run: npm install -g grunt-cli 
       - run: gem install compass  

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ These steps need to performed ONLY the FIRST TIME you set up this code.
 4. Install Compass:
    - Compass compiles SASS/SCSS into CSS.
    - Requires ruby (It's recommended to install ruby also using rvm. See install [rvm with ruby](https://stackify.com/rvm-how-to-get-started-and-manage-your-ruby-installations/)).
-   - Ruby version: 2.6.6 
+   - Ruby version: 3.1
    - Once ruby is installed, you can install compass using: `gem install compass`
 
 ### Build commands


### PR DESCRIPTION
JIRA -> https://bahmni.atlassian.net/browse/BAH-3923

The Bahmniapps workflow was failing because the installed version of RubyGems (2.7.6.3) was too old to support the required version of the ffi gem for Compass. To resolve this issue, RubyGems needed to be updated to a version meeting the minimum requirement for ffi (>= 3.3.22). For this, the Ruby version had to be upgraded to greater than 3. Therefore, the Ruby version has been upgraded to 3.1.