### PR TITLE
BAH-3983 | Fix. Remove Broken IPD Tab in Clinical

### DIFF
--- a/ui/app/clinical/dashboard/services/clinicalDashboardConfig.js
+++ b/ui/app/clinical/dashboard/services/clinicalDashboardConfig.js
@@ -3,17 +3,9 @@
 angular.module('bahmni.clinical')
     .service('clinicalDashboardConfig', ['appService', function (appService) {
         var self = this;
-
-        var customIPD = {
-            displayByDefault: false,
-            sections: {},
-            maxRecentlyViewedPatients: 10,
-            translationKey: "DASHBOARD_TAB_IPD_KEY"
-        };
         this.load = function () {
             return appService.loadConfig('dashboard.json').then(function (response) {
-                var hacked = Object.assign({}, response, {IPD: customIPD});
-                angular.extend(self, new Bahmni.Clinical.ClinicalDashboardConfig(_.values(hacked)));
+                angular.extend(self, new Bahmni.Clinical.ClinicalDashboardConfig(_.values(response)));
             });
         };
     }]);


### PR DESCRIPTION
JIRA -> [BAH-3983](https://bahmni.atlassian.net/browse/BAH-3983)

The IPD Dashboard Tab was originally added to display the IPD Dashboard, which was later added as a micro frontend, replacing the need for this tab. In this PR, the broken IPD Dashboard Tab has been removed.