### PR TITLE
BAH-4009 | Add. Missing Translations In Bed, ADT

### DIFF
--- a/ui/app/i18n/adt/locale_en.json
+++ b/ui/app/i18n/adt/locale_en.json
@@ -69,5 +69,6 @@
     "IPD_WARD_LIST_SEARCH_KEY": "Search...",
     "CARE_VIEW_LABEL": "Change to Care View",
     "LOGOUT_TRANSLATION_KEY": "Logout",
-    "MESSAGE_AUTO_CONVERT_TO_IPD_VISIT": "{{visitType}} Visit Started Successfully"
+    "MESSAGE_AUTO_CONVERT_TO_IPD_VISIT": "{{visitType}} Visit Started Successfully",
+    "DAYS_ADMITTED_MESSAGE": "Days in hospital"
 }

--- a/ui/app/i18n/ipd/locale_en.json
+++ b/ui/app/i18n/ipd/locale_en.json
@@ -77,5 +77,7 @@
     "BED": "Bed",
     "CARE_VIEW_LABEL": "Change to Care View",
     "MESSAGE_AUTO_CONVERT_TO_IPD_VISIT": "{{visitType}} Visit Started Successfully",
-    "LOGOUT_TRANSLATION_KEY": "Logout"
+    "LOGOUT_TRANSLATION_KEY": "Logout",
+    "DAYS_ADMITTED_MESSAGE": "Days in hospital",
+    "DISCHARGE_DATE_LABEL": "Discharge Date"
 }


### PR DESCRIPTION
JIRA -> [BAH-4009](https://bahmni.atlassian.net/browse/BAH-4009)

In this PR, missing translations for certain labels in the Admission Details display control has been added back in. Specifically, the `DISCHARGE_DATE_LABEL` and `DAYS_ADMITTED_MESSAGE` were not translated and are showing the placeholder text instead.


|Fixed Bed management Screen|Fixed ADT Screen|
|-|-|
|![Screenshot 2024-07-09 at 9 18 20 AM](https://github.com/Bahmni/openmrs-module-bahmniapps/assets/121226043/d91146cb-3f8e-401f-92cc-b903a2ccf87a)|![Screenshot 2024-07-09 at 9 18 37 AM](https://github.com/Bahmni/openmrs-module-bahmniapps/assets/121226043/fc4e2ef1-571e-4a01-896c-cb094e39d383)|



