### PR TITLE
BAH-3971 | Add. Context Between Logout and Re-Login for All Bahmni Modules

### DIFF
--- a/ui/app/admin/initialization.js
+++ b/ui/app/admin/initialization.js
@@ -7,7 +7,7 @@ angular.module('bahmni.admin')
             var configNames = ['quickLogoutComboKey', 'contextCookieExpirationTimeInMinutes'];
             return configurations.load(configNames).then(function () {
                 $rootScope.quickLogoutComboKey = configurations.quickLogoutComboKey() || 'Escape';
-                $rootScope.cookieExpiryTime = configurations.contextCookieExpirationTimeInMinutes() || 30;
+                $rootScope.cookieExpiryTime = configurations.contextCookieExpirationTimeInMinutes() || 0;
             });
         };
 

--- a/ui/app/adt/initialization.js
+++ b/ui/app/adt/initialization.js
@@ -12,7 +12,7 @@ angular.module('bahmni.adt').factory('initialization', ['$rootScope', '$q', 'app
                 $rootScope.relationshipTypeMap = configurations.relationshipTypeMap();
                 $rootScope.diagnosisStatus = (appService.getAppDescriptor().getConfig("diagnosisStatus") && appService.getAppDescriptor().getConfig("diagnosisStatus").value || "RULED OUT");
                 $rootScope.quickLogoutComboKey = configurations.quickLogoutComboKey() || 'Escape';
-                $rootScope.cookieExpiryTime = configurations.contextCookieExpirationTimeInMinutes() || 30;
+                $rootScope.cookieExpiryTime = configurations.contextCookieExpirationTimeInMinutes() || 0;
                 config.resolve();
             });
             return config.promise;

--- a/ui/app/bedmanagement/initialization.js
+++ b/ui/app/bedmanagement/initialization.js
@@ -12,7 +12,7 @@ angular.module('bahmni.ipd').factory('initialization', ['$rootScope', '$q', '$ba
                 $rootScope.relationshipTypeMap = configurations.relationshipTypeMap();
                 $rootScope.diagnosisStatus = ((appService.getAppDescriptor().getConfig("diagnosisStatus") && appService.getAppDescriptor().getConfig("diagnosisStatus").value) || "RULED OUT");
                 $rootScope.quickLogoutComboKey = configurations.quickLogoutComboKey() || 'Escape';
-                $rootScope.cookieExpiryTime = configurations.contextCookieExpirationTimeInMinutes() || 30;
+                $rootScope.cookieExpiryTime = configurations.contextCookieExpirationTimeInMinutes() || 0;
                 config.resolve();
             });
             return config.promise;

--- a/ui/app/clinical/initialization.js
+++ b/ui/app/clinical/initialization.js
@@ -27,7 +27,7 @@ angular.module('bahmni.clinical').factory('initialization',
                         $rootScope.diagnosisStatus = (appService.getAppDescriptor().getConfig("diagnosisStatus") && appService.getAppDescriptor().getConfig("diagnosisStatus").value || "RULED OUT");
                         $rootScope.prescriptionEmailToggle = configurations.prescriptionEmailToggle();
                         $rootScope.quickLogoutComboKey = configurations.quickLogoutComboKey() || 'Escape';
-                        $rootScope.cookieExpiryTime = configurations.contextCookieExpirationTimeInMinutes() || 30;
+                        $rootScope.cookieExpiryTime = configurations.contextCookieExpirationTimeInMinutes() || 0;
                     });
                 };
 

--- a/ui/app/common/auth/authentication.js
+++ b/ui/app/common/auth/authentication.js
@@ -78,7 +78,8 @@ angular.module('authentication')
             if ($rootScope.cookieExpiryTime && $rootScope.cookieExpiryTime > 0) {
                 var currentTime = new Date();
                 var expiryTime = new Date(currentTime.getTime() + $rootScope.cookieExpiryTime * 60000);
-                $bahmniCookieStore.put($rootScope.currentProvider.uuid, $window.location.pathname + $window.location.hash, {path: '/', expires: expiryTime});
+                var params = (decodeURIComponent($window.location.search.substring(1)));
+                $bahmniCookieStore.put($rootScope.currentProvider.uuid, $window.location.pathname + (params ? '?' + params : '') + $window.location.hash, {path: '/', expires: expiryTime});
             }
             return $http.delete(sessionResourcePath);
         };

--- a/ui/app/common/auth/authentication.js
+++ b/ui/app/common/auth/authentication.js
@@ -75,9 +75,9 @@ angular.module('authentication')
         var self = this;
 
         var destroySessionFromServer = function () {
-            var currentTime = new Date();
-            var expiryTime = new Date(currentTime.getTime() + $rootScope.cookieExpiryTime * 60000);
-            if ($window.location.hash.includes("careViewDashboard") || $window.location.hash.includes("ipd")) {
+            if ($rootScope.cookieExpiryTime && $rootScope.cookieExpiryTime > 0) {
+                var currentTime = new Date();
+                var expiryTime = new Date(currentTime.getTime() + $rootScope.cookieExpiryTime * 60000);
                 $bahmniCookieStore.put($rootScope.currentProvider.uuid, $window.location.pathname + $window.location.hash, {path: '/', expires: expiryTime});
             }
             return $http.delete(sessionResourcePath);
@@ -139,8 +139,7 @@ angular.module('authentication')
                 userService.getProviderForUser(data.results[0].uuid).then(function (providers) {
                     if (!_.isEmpty(providers.results) && hasAnyActiveProvider(providers.results)) {
                         $rootScope.currentUser = new Bahmni.Auth.User(data.results[0]);
-                        $rootScope.currentUser.provider = providers.results[0];
-                        $rootScope.currentUser.currentLocation = null;
+                        $rootScope.currentUser.currentLocation = $bahmniCookieStore.get(Bahmni.Common.Constants.locationCookieName).name;
                         $rootScope.$broadcast('event:user-credentialsLoaded', data.results[0]);
                         deferrable.resolve(data.results[0]);
                     } else {

--- a/ui/app/document-upload/initialization.js
+++ b/ui/app/document-upload/initialization.js
@@ -12,7 +12,7 @@ angular.module('opd.documentupload').factory('initialization',
                 return configurations.load(configNames).then(function () {
                     $rootScope.genderMap = configurations.genderMap();
                     $rootScope.quickLogoutComboKey = configurations.quickLogoutComboKey() || 'Escape';
-                    $rootScope.cookieExpiryTime = configurations.contextCookieExpirationTimeInMinutes() || 30;
+                    $rootScope.cookieExpiryTime = configurations.contextCookieExpirationTimeInMinutes() || 0;
                 });
             };
 

--- a/ui/app/home/initialization.js
+++ b/ui/app/home/initialization.js
@@ -4,8 +4,9 @@ angular.module('bahmni.home')
     .factory('initialization', ['$rootScope', 'appService', 'spinner', 'configurationService',
         function ($rootScope, appService, spinner, configurationService) {
             var getConfigs = function () {
-                configurationService.getConfigurations(['quickLogoutComboKey']).then(function (response) {
+                configurationService.getConfigurations(['quickLogoutComboKey', 'contextCookieExpirationTimeInMinutes']).then(function (response) {
                     $rootScope.quickLogoutComboKey = response.quickLogoutComboKey || 'Escape';
+                    $rootScope.cookieExpiryTime = response.contextCookieExpirationTimeInMinutes || 0;
                 });
             };
             var initApp = function () {

--- a/ui/app/orders/initialization.js
+++ b/ui/app/orders/initialization.js
@@ -5,7 +5,7 @@ angular.module('bahmni.orders')
     function ($rootScope, $q, appService, spinner, configurations, orderTypeService, locationService) {
         var getConfigs = function () {
             var config = $q.defer();
-            var configNames = ['encounterConfig', 'patientConfig', 'genderMap', 'relationshipTypeMap', 'quickLogoutComboKey'];
+            var configNames = ['encounterConfig', 'patientConfig', 'genderMap', 'relationshipTypeMap', 'quickLogoutComboKey', 'contextCookieExpirationTimeInMinutes'];
             configurations.load(configNames).then(function () {
                 var conceptConfig = appService.getAppDescriptor().getConfigValue("conceptSetUI");
                 var customLocationTags = _.get(conceptConfig, 'facilityLocationTags');
@@ -18,6 +18,7 @@ angular.module('bahmni.orders')
                 $rootScope.genderMap = configurations.genderMap();
                 $rootScope.relationshipTypeMap = configurations.relationshipTypeMap();
                 $rootScope.quickLogoutComboKey = configurations.quickLogoutComboKey() || 'Escape';
+                $rootScope.cookieExpiryTime = configurations.contextCookieExpirationTimeInMinutes() || 0;
                 config.resolve();
             });
             return config.promise;

--- a/ui/app/ot/initialization.js
+++ b/ui/app/ot/initialization.js
@@ -6,7 +6,7 @@ angular.module('bahmni.ot').factory('initialization', ['$rootScope', '$q', 'surg
             var configNames = ['quickLogoutComboKey', 'contextCookieExpirationTimeInMinutes'];
             return configurations.load(configNames).then(function () {
                 $rootScope.quickLogoutComboKey = configurations.quickLogoutComboKey() || 'Escape';
-                $rootScope.cookieExpiryTime = configurations.contextCookieExpirationTimeInMinutes() || 30;
+                $rootScope.cookieExpiryTime = configurations.contextCookieExpirationTimeInMinutes() || 0;
             });
         };
         var initApp = function () {

--- a/ui/app/registration/initialization.js
+++ b/ui/app/registration/initialization.js
@@ -4,7 +4,7 @@ angular.module('bahmni.registration').factory('initialization',
     ['$rootScope', '$q', 'configurations', 'authenticator', 'appService', 'spinner', 'preferences', 'locationService', 'mergeService', '$translate',
         function ($rootScope, $q, configurations, authenticator, appService, spinner, preferences, locationService, mergeService, $translate) {
             var getConfigs = function () {
-                var configNames = ['encounterConfig', 'patientAttributesConfig', 'identifierTypesConfig', 'addressLevels', 'genderMap', 'relationshipTypeConfig', 'relationshipTypeMap', 'loginLocationToVisitTypeMapping', 'helpDeskNumber', 'quickLogoutComboKey'];
+                var configNames = ['encounterConfig', 'patientAttributesConfig', 'identifierTypesConfig', 'addressLevels', 'genderMap', 'relationshipTypeConfig', 'relationshipTypeMap', 'loginLocationToVisitTypeMapping', 'helpDeskNumber', 'quickLogoutComboKey', 'contextCookieExpirationTimeInMinutes'];
                 return configurations.load(configNames).then(function () {
                     var mandatoryPersonAttributes = appService.getAppDescriptor().getConfigValue("mandatoryPersonAttributes");
                     var patientAttributeTypes = new Bahmni.Common.Domain.AttributeTypeMapper().mapFromOpenmrsAttributeTypes(configurations.patientAttributesConfig(), mandatoryPersonAttributes, {}, $rootScope.currentUser.userProperties.defaultLocale);
@@ -22,6 +22,7 @@ angular.module('bahmni.registration').factory('initialization',
                     $rootScope.relationshipTypeMap = configurations.relationshipTypeMap();
                     $rootScope.relationshipTypes = configurations.relationshipTypes();
                     $rootScope.quickLogoutComboKey = configurations.quickLogoutComboKey() || 'Escape';
+                    $rootScope.cookieExpiryTime = configurations.contextCookieExpirationTimeInMinutes() || 0;
                 });
             };
 

--- a/ui/app/reports/initialization.js
+++ b/ui/app/reports/initialization.js
@@ -8,7 +8,7 @@ angular.module('bahmni.reports').factory('initialization',
                     var configNames = ['quickLogoutComboKey', 'contextCookieExpirationTimeInMinutes'];
                     return configurations.load(configNames).then(function () {
                         $rootScope.quickLogoutComboKey = configurations.quickLogoutComboKey() || 'Escape';
-                        $rootScope.cookieExpiryTime = configurations.contextCookieExpirationTimeInMinutes() || 30;
+                        $rootScope.cookieExpiryTime = configurations.contextCookieExpirationTimeInMinutes() || 0;
                     });
                 };
                 var initApp = function () {


### PR DESCRIPTION
JIRA -> [BAH-3971](https://bahmni.atlassian.net/browse/BAH-3971)

This pull request introduces context support between logout and re-login for all Bahmni apps modules. This feature is enabled when the global property `contextcookieexpirationtimeinminutes` is set to a non-null positive integer. When this property is set, the page from which the user logs out will be stored in the context, and upon re-login, the user will be redirected to the same page.