### PR TITLE
BAH-4037 | Add. Configuration to support specifying orderTypeClassMap

### DIFF
--- a/ui/app/clinical/consultation/controllers/orderController.js
+++ b/ui/app/clinical/consultation/controllers/orderController.js
@@ -150,7 +150,9 @@ angular.module('bahmni.clinical')
                 $scope.activeTab.leftCategory = leftCategory;
                 $scope.activeTab.leftCategory.klass = "active";
 
-                $scope.activeTab.leftCategory.groups = $scope.getConceptClassesInSet(leftCategory);
+                var conceptClasses = $scope.getConceptClassesInSet(leftCategory);
+                var conceptClassesFilteredForOrderType = $scope.filterConceptClassesForOrderType(conceptClasses, $scope.activeTab.name);
+                $scope.activeTab.leftCategory.groups = conceptClassesFilteredForOrderType;
             };
 
             $scope.getConceptClassesInSet = function (conceptSet) {
@@ -162,6 +164,18 @@ angular.module('bahmni.clinical')
                 conceptClasses = _.sortBy(conceptClasses, 'name');
                 return conceptClasses;
             };
+
+            $scope.filterConceptClassesForOrderType = function (conceptClasses,orderTypeName) {
+                var orderTypeClassMapConfig = appService.getAppDescriptor().getConfig("orderTypeClassMap");
+                var orderTypeClassMap = orderTypeClassMapConfig ? orderTypeClassMapConfig.value : {};
+                if (!_.isEmpty(orderTypeClassMap[orderTypeName])) {
+                    return _.filter(conceptClasses, function (conceptClass) {
+                        return _.includes(orderTypeClassMap[orderTypeName], conceptClass.name);
+                    });
+                }
+                return conceptClasses;
+                
+            }
 
             $scope.$watchCollection('consultation.orders', $scope.updateSelectedOrdersForActiveTab);
 


### PR DESCRIPTION
This PR enhances the Order Controller to display concepts containing a specific class of concepts for each order type. This is to support using the same grouping concept across order types. The configuration can be added in implementation-config `clinical/app.json` under config section. 
Example:
```json
"orderTypeClassMap" :{
            "Laboratory": ["Test",,"LabTest","LabSet"],
            "Radiology Orders": ["Radiology","Radiology/Imaging Procedure"],
            "Procedure Orders": ["Procedure"]
        },
```
**Backward Compatible: If the config is not specified, then all the concepts under the set is displayed.**

_Without Config:_
<img width="1325" alt="image" src="https://github.com/user-attachments/assets/b695e0bb-87af-4354-a9d4-ec60f075dd42">

_With Config:_
<img width="1315" alt="image" src="https://github.com/user-attachments/assets/afc573b3-a96c-49dd-b3b4-dbfef916d981">



