### PR TITLE
BAH-4053 | FIx. Add condition to show all providers in OT when a filter config is not passed.

### DIFF
--- a/ui/app/ot/helpers/surgicalAppointmentHelper.js
+++ b/ui/app/ot/helpers/surgicalAppointmentHelper.js
@@ -3,6 +3,11 @@
 angular.module('bahmni.ot')
     .service('surgicalAppointmentHelper', [function () {
         this.filterProvidersByName = function (providerNames, providers) {
+            if (!providerNames || providerNames.length === 0) {
+                return _.filter(providers, function (provider) {
+                    return provider.person.display!="";
+                });
+            }
             var validProviderNames = _.filter(providerNames, function (providerName) {
                 return _.find(providers, function (provider) {
                     return providerName === provider.person.display;

--- a/ui/app/ot/helpers/surgicalAppointmentHelper.js
+++ b/ui/app/ot/helpers/surgicalAppointmentHelper.js
@@ -5,7 +5,7 @@ angular.module('bahmni.ot')
         this.filterProvidersByName = function (providerNames, providers) {
             if (!providerNames || providerNames.length === 0) {
                 return _.filter(providers, function (provider) {
-                    return provider.person.display!="";
+                    return provider.person.display != "";
                 });
             }
             var validProviderNames = _.filter(providerNames, function (providerName) {

--- a/ui/test/unit/ot/helpers/surgicalAppointmentHelper.spec.js
+++ b/ui/test/unit/ot/helpers/surgicalAppointmentHelper.spec.js
@@ -34,6 +34,35 @@ describe('surgicalAppointmentHelper', function () {
         expect(filteredProviders[2]).toEqual({uuid: "uuid2", person: {display: "Provider2"}});
     });
 
+    it('should return all providers with a display name when an empty list of names is passed', function () {
+        var providerNames = [];
+        var providers = [{uuid: "uuid1", person: { display: "Provider1"}}, {uuid: "uuid2", person: { display: "Provider2"}}];
+        var filteredProviders = surgicalAppointmentHelper.filterProvidersByName(providerNames, providers);
+
+        expect(filteredProviders.length).toEqual(2);
+        expect(filteredProviders[0]).toEqual({uuid: "uuid1", person: {display: "Provider1"}});
+        expect(filteredProviders[1]).toEqual({uuid: "uuid2", person: {display: "Provider2"}});
+    });
+
+    it('should return all providers with a display name when the list of names is undefined', function () {
+        var providerNames = undefined;
+        var providers = [{ uuid: "uuid1", person: { display: "Provider1" } }, { uuid: "uuid2", person: { display: "Provider2" } }];
+        var filteredProviders = surgicalAppointmentHelper.filterProvidersByName(providerNames, providers);
+
+        expect(filteredProviders.length).toEqual(2);
+        expect(filteredProviders[0]).toEqual({ uuid: "uuid1", person: { display: "Provider1" } });
+        expect(filteredProviders[1]).toEqual({ uuid: "uuid2", person: { display: "Provider2" } });
+    });
+
+    it('should not return providers with an empty display name and when the an empty list of names is passed', function () {
+        var providerNames = [];
+        var providers = [{ uuid: "uuid1", person: { display: "Provider1" } }, { uuid: "uuid2", person: { display: "" } }];
+        var filteredProviders = surgicalAppointmentHelper.filterProvidersByName(providerNames, providers);
+
+        expect(filteredProviders.length).toEqual(1);
+        expect(filteredProviders[0]).toEqual({ uuid: "uuid1", person: { display: "Provider1" } });
+    });
+
     it('should get the duration in minutes', function () {
         var estTimInHours = "1";
         var estTimInMinutes = "15";


### PR DESCRIPTION
This PR adds a condition to show all the providers with a display name in the OT module when the `primarySurgeonsForOT` configuration is either empty or undefined