### PR TITLE
BAH-3845 | Fix. Remove filter for IPD Visit while opening IPD Visit

### DIFF
--- a/ui/app/clinical/common/controllers/visitController.js
+++ b/ui/app/clinical/common/controllers/visitController.js
@@ -29,7 +29,7 @@ angular.module('bahmni.clinical')
             $scope.visitUuid = $stateParams.visitUuid;
             $scope.isActiveIpdVisit = $scope.visitSummary.visitType === "IPD";
             $scope.isIpdReadMode = true;
-            if ($scope.visitSummary.visitType === "IPD" && $scope.visitSummary.stopDateTime === null) {
+            if ($scope.visitSummary.stopDateTime === null) {
                 $scope.isIpdReadMode = false;
             }
             $scope.ipdDashboard = {


### PR DESCRIPTION
This PR removes the filter for IPD visit while setting readMode, due to which IPD Dashboard breaks and shows invalid dates when a patient is admitted from visit other than IPD.

| Before Fix | After Fix |
|--------|--------|
| <img width="1542" alt="image" src="https://github.com/user-attachments/assets/ceeb8aa1-4b28-45e4-9ae3-1ef3dc62f486">   | <img width="1531" alt="image" src="https://github.com/user-attachments/assets/14a0496d-8bbb-4bb1-a038-5686351f510b"> | 
