### PR TITLE
BAH-4058 | Fix. Remove Form Name From Observation Display Control

### DIFF
--- a/ui/app/common/obs/views/showObservation.html
+++ b/ui/app/common/obs/views/showObservation.html
@@ -1,6 +1,6 @@
 <li ng-class="::{'is-text': observation.type == 'Text', 'has-child' : observation.groupMembers.length > 0 ,'video-concept':observation.isVideoConcept(), 'image-preview': observation.isImageConcept()}" >
     <div ng-class="::{'is-abnormal': (observation.abnormal ==  true || observation.interpretation === 'ABNORMAL')}" class="tree-list-item clearfix" bm-gallery patient="patient">
-        <span ng-show="observation.groupMembers.length!==0" ng-if="::(!observation.isImageConcept() || (observation.isImageConcept() && !print))" class="testUnderPanel left">
+        <span ng-hide="!observation.isImageConcept()" ng-if="::(!observation.isImageConcept() || (observation.isImageConcept() && !print))" class="testUnderPanel left">
             <label class="obs-label" ng-if="::configIsObservationForImages">{{::(observation.concept.shortName || observation.concept.name)}}</label>
             <label ng-if="::!configIsObservationForImages">{{::(observation.concept.shortName || observation.concept.name)}}</label>
             <hint concept-details="::{


### PR DESCRIPTION
Jira -> [BAH-4058](https://bahmni.atlassian.net/browse/BAH-4058)

This PR, aims to remove the form name from getting displayed in the `observation` display control.
![Screenshot 2024-08-04 at 9 18 32 PM](https://github.com/user-attachments/assets/ec67bda5-6370-4c8f-980c-6b2d292dd331)
