### PR TITLE
BAH-4064 | Refactor. IPD Dashboard Link Position

### DIFF
--- a/ui/app/clinical/consultation/models/visitHistoryEntry.js
+++ b/ui/app/clinical/consultation/models/visitHistoryEntry.js
@@ -10,8 +10,8 @@ Bahmni.Clinical.VisitHistoryEntry = (function () {
             return this.stopDatetime === null;
         },
 
-        isActiveIPDVisit: function () {
-            return this.stopDatetime === null && (this.visitType.name || this.visitType.display) === "IPD";
+        isIPDVisit: function () {
+            return (this.visitType.name || this.visitType.display) === "IPD";
         },
 
         isFromCurrentLocation: function (currentVisitLocation) {

--- a/ui/app/clinical/consultation/models/visitHistoryEntry.js
+++ b/ui/app/clinical/consultation/models/visitHistoryEntry.js
@@ -10,6 +10,10 @@ Bahmni.Clinical.VisitHistoryEntry = (function () {
             return this.stopDatetime === null;
         },
 
+        isActiveIPDVisit: function () {
+            return this.stopDatetime === null && (this.visitType.name || this.visitType.display) === "IPD";
+        },
+
         isFromCurrentLocation: function (currentVisitLocation) {
             var visitLocation = _.get(this.location, 'uuid');
             return visitLocation === currentVisitLocation;

--- a/ui/app/clinical/displaycontrols/allvisits/directives/visitsTable.js
+++ b/ui/app/clinical/displaycontrols/allvisits/directives/visitsTable.js
@@ -4,7 +4,7 @@ angular.module('bahmni.clinical')
     .directive('visitsTable', ['patientVisitHistoryService', 'conceptSetService', 'spinner', '$state', '$q', '$translate', 'appService',
         function (patientVisitHistoryService, conceptSetService, spinner, $state, $q, $translate, appService) {
             var controller = function ($scope) {
-                const enableIPDFeature = appService.getAppDescriptor().getConfigValue('enableIPDFeature');
+                $scope.enableIPDFeature = appService.getAppDescriptor().getConfigValue('enableIPDFeature');
                 var emitNoDataPresentEvent = function () {
                     $scope.$emit("no-data-present-event");
                 };

--- a/ui/app/clinical/displaycontrols/allvisits/directives/visitsTable.js
+++ b/ui/app/clinical/displaycontrols/allvisits/directives/visitsTable.js
@@ -8,15 +8,19 @@ angular.module('bahmni.clinical')
                 var emitNoDataPresentEvent = function () {
                     $scope.$emit("no-data-present-event");
                 };
+
                 $scope.openVisit = function (visit) {
                     if ($scope.$parent.closeThisDialog) {
                         $scope.$parent.closeThisDialog("closing modal");
                     }
-                    if (visit.visitType.display === "IPD" && enableIPDFeature) {
-                        $state.go('patient.dashboard.ipdVisit', {visitUuid: visit.uuid, source: 'clinical'});
-                    } else {
-                        $state.go('patient.dashboard.visit', {visitUuid: visit.uuid});
+                    $state.go('patient.dashboard.visit', {visitUuid: visit.uuid});
+                };
+
+                $scope.openIPDDashboard = function (visit) {
+                    if ($scope.$parent.closeThisDialog) {
+                        $scope.$parent.closeThisDialog("closing modal");
                     }
+                    $state.go('patient.dashboard.ipdVisit', {visitUuid: visit.uuid, source: 'clinical'});
                 };
 
                 $scope.hasVisits = function () {

--- a/ui/app/clinical/displaycontrols/allvisits/views/visitsTable.html
+++ b/ui/app/clinical/displaycontrols/allvisits/views/visitsTable.html
@@ -11,7 +11,7 @@
         <table class="visits dashboard-table" id="visitDisplayTable" ng-if="::hasVisits()">
             <tbody>
             <tr id="eachVisit" ng-repeat="visit in ::visits | limitTo: params.maximumNoOfVisits">
-                <td class="name" width="50%">
+                <td class="name" width="40%">
                     <a class="visit" ng-click="openVisit(visit)">
                         <span>{{::visit.startDatetime | bahmniDate}}</span>
                         <span ng-if="::!visit.isOneDayVisit()">- {{::visit.stopDatetime | bahmniDate }}</span>
@@ -19,13 +19,12 @@
                            title="Current Visit"></i>
                     </a>
                 </td>
-                <td class="value" id="visitType" ng-if="::visit.isActiveIPDVisit()">
+                <td class="value" id="visitType">{{::translateVisitTypes(visit.getVisitType())}}</td>
+                <td class="value" id="visitType" ng-if="::visit.isIPDVisit()">
                     <a class="visit" ng-click="openIPDDashboard(visit)">
-                        {{::translateVisitTypes(visit.getVisitType())}}
+                        {{::'VIEW_IPD_DASHBOARD'|translate}}
+                        <i class="fa fa-external-link"></i>
                     </a>
-                </td>
-                <td class="value" id="visitType" ng-if="::!visit.isActiveIPDVisit()">
-                    {{::translateVisitTypes(visit.getVisitType())}}
                 </td>
             </tr>
             </tbody>

--- a/ui/app/clinical/displaycontrols/allvisits/views/visitsTable.html
+++ b/ui/app/clinical/displaycontrols/allvisits/views/visitsTable.html
@@ -19,7 +19,14 @@
                            title="Current Visit"></i>
                     </a>
                 </td>
-                <td class="value" id="visitType">{{::translateVisitTypes(visit.getVisitType())}}</td>
+                <td class="value" id="visitType" ng-if="::visit.isActiveIPDVisit()">
+                    <a class="visit" ng-click="openIPDDashboard(visit)">
+                        {{::translateVisitTypes(visit.getVisitType())}}
+                    </a>
+                </td>
+                <td class="value" id="visitType" ng-if="::!visit.isActiveIPDVisit()">
+                    {{::translateVisitTypes(visit.getVisitType())}}
+                </td>
             </tr>
             </tbody>
         </table>

--- a/ui/app/clinical/displaycontrols/allvisits/views/visitsTable.html
+++ b/ui/app/clinical/displaycontrols/allvisits/views/visitsTable.html
@@ -20,7 +20,7 @@
                     </a>
                 </td>
                 <td class="value" id="visitType">{{::translateVisitTypes(visit.getVisitType())}}</td>
-                <td class="value" id="visitType" ng-if="::visit.isIPDVisit()">
+                <td class="value" id="visitType" ng-show="::enableIPDFeature" ng-if="::visit.isIPDVisit()">
                     <a class="visit" ng-click="openIPDDashboard(visit)">
                         {{::'VIEW_IPD_DASHBOARD'|translate}}
                         <i class="fa fa-external-link"></i>

--- a/ui/app/common/displaycontrols/navigationlinks/directives/navigationLinks.js
+++ b/ui/app/common/displaycontrols/navigationlinks/directives/navigationLinks.js
@@ -45,12 +45,6 @@ angular.module('bahmni.common.displaycontrol.navigationlinks')
                     "translationKey": "PATIENT_REGISTRATION_PAGE_KEY",
                     "url": "../registration/#/patient/{{patientUuid}}",
                     "title": "Registration"
-                },
-                {
-                    "name": "labEntry",
-                    "translationKey": "LAB_ENTRY_KEY",
-                    "url": "/lab/patient/{{patientUuid}}",
-                    "title": "Lab Entry"
                 }
             ];
 

--- a/ui/app/i18n/clinical/locale_en.json
+++ b/ui/app/i18n/clinical/locale_en.json
@@ -201,7 +201,7 @@
     "MESSAGE_DIALOG_OPTION_OKAY": "OK",
     "MESSAGE_DIALOG_OPTION_REVIEW": "Review",
     "MESSAGE_DIALOG_OPTION_DISCARD": "Discard",
-    "LAB_ENTRY_KEY": "Lab Entry",
+    "VIEW_IPD_DASHBOARD": "View IPD Dashboard",
     "OBS_BOOLEAN_YES_KEY": "Yes",
     "OBS_BOOLEAN_NO_KEY": "No",
     "CLINICAL_DUPLICATE_DIAGNOSIS_ERROR_MESSAGE": "Please correct the duplicate diagnosis entered.",


### PR DESCRIPTION
JIRA -> [BAH-4064](https://bahmni.atlassian.net/browse/BAH-4064)

In this PR aims to revert the recent changes made to the patient dashboard that open the IPD dashboard when the active visit link is clicked. This change breaks the existing patient dashboard flow and is not backward compatible. Instead, introduce a new link in the links tile that, when clicked, takes the user to the IPD dashboard for the current patient. The link will be enabled only when the `enableIPDFeature` config is set to true in openmrs/apps/clinical/app.json.

![Screenshot 2024-08-13 at 7 47 47 AM](https://github.com/user-attachments/assets/258249b9-36a6-47bc-8cad-9cf744450c78)

