### PR TITLE
BAH-4062 | Add. Pass currentUser to IPD Dashboard scope

### DIFF
--- a/ui/app/adt/controllers/adtController.js
+++ b/ui/app/adt/controllers/adtController.js
@@ -19,6 +19,7 @@ angular.module('bahmni.adt')
             $scope.getAdtConceptConfig = $scope.dashboardConfig.conceptName;
             $scope.hostData = {
                 patient: $scope.patient,
+                currentUser: $rootScope.currentUser,
                 provider: $rootScope.currentProvider
             };
 

--- a/ui/app/adt/controllers/careViewController.js
+++ b/ui/app/adt/controllers/careViewController.js
@@ -13,6 +13,7 @@ angular.module('bahmni.adt')
     $window.addEventListener('keydown', handleLogoutShortcut);
     $scope.$on('$destroy', cleanup);
     $scope.hostData = {
+        currentUser: $rootScope.currentUser,
         provider: $rootScope.currentProvider
     };
     $scope.hostApi = {

--- a/ui/app/bedmanagement/controllers/careViewController.js
+++ b/ui/app/bedmanagement/controllers/careViewController.js
@@ -13,7 +13,8 @@ angular.module('bahmni.ipd')
     $window.addEventListener('keydown', handleLogoutShortcut);
     $scope.$on('$destroy', cleanup);
     $scope.hostData = {
-        provider: $rootScope.currentProvider
+        provider: $rootScope.currentProvider,
+        currentUser: $rootScope.currentUser
     };
     $scope.hostApi = {
         onHome: function () {

--- a/ui/app/clinical/common/controllers/visitController.js
+++ b/ui/app/clinical/common/controllers/visitController.js
@@ -38,6 +38,7 @@ angular.module('bahmni.clinical')
                     visitSummary: $scope.visitSummary,
                     forDate: new Date().toUTCString(),
                     provider: $rootScope.currentProvider,
+                    currentUser: $rootScope.currentUser,
                     visitUuid: $scope.visitUuid,
                     isReadMode: $scope.isIpdReadMode,
                     source: $location.search().source

--- a/ui/test/unit/adt/controllers/careViewController.spec.js
+++ b/ui/test/unit/adt/controllers/careViewController.spec.js
@@ -26,11 +26,12 @@ describe("CareViewController", function () {
         then: function() { }
     });
     let mockProvider = {name: "__test__provider"}
+    let mockUser = {name: "__test__user"}
     var createController = function () {
 
         controller('CareViewController', {
             $scope: scope,
-            $rootScope: {currentProvider: mockProvider, quickLogoutComboKey: 'Escape', cookieExpiryTime:30},
+            $rootScope: {currentProvider: mockProvider, quickLogoutComboKey: 'Escape', cookieExpiryTime:30, currentUser: mockUser},
             $state: state,
             auditLogService: auditLogService,
             sessionService: sessionService,
@@ -40,7 +41,7 @@ describe("CareViewController", function () {
 
     it('should create host data and host api', function (){
         createController();
-        expect(scope.hostData).toEqual({provider: mockProvider});
+        expect(scope.hostData).toEqual({provider: mockProvider, currentUser: mockUser});
         expect(scope.hostApi).not.toBeNull();
     });
 

--- a/ui/test/unit/bedmanagement/controllers/careViewController.spec.js
+++ b/ui/test/unit/bedmanagement/controllers/careViewController.spec.js
@@ -18,11 +18,12 @@ describe("CareViewController", function () {
         then: function() { }
     });
     let mockProvider = {name: "__test__provider"}
+    let mockUser = { name: "__test__user" }
     var createController = function () {
 
         controller('CareViewController', {
             $scope: scope,
-            $rootScope: {currentProvider: mockProvider, quickLogoutComboKey: 'Escape', cookieExpiryTime:30},
+            $rootScope: {currentProvider: mockProvider, quickLogoutComboKey: 'Escape', cookieExpiryTime:30, currentUser: mockUser},
             $state: state,
             auditLogService: auditLogService,
             sessionService: sessionService,
@@ -32,7 +33,7 @@ describe("CareViewController", function () {
 
     it('should create host data and host api', function (){
         createController();
-        expect(scope.hostData).toEqual({provider: mockProvider});
+        expect(scope.hostData).toEqual({provider: mockProvider, currentUser: mockUser});
         expect(scope.hostApi).not.toBeNull();
     });
 


### PR DESCRIPTION
This PR adds changes to pass the currentUser information to the IPD Dashboard scope through `hostData`