### PR TITLE
BAH-4118 | Fix. Extension Iframe height to be responsive

### DIFF
--- a/ui/app/styles/registration/_registration.scss
+++ b/ui/app/styles/registration/_registration.scss
@@ -251,7 +251,7 @@ body {
         padding: 20px;
         border: 1px solid #888;
         width: 40%;
-        height: 600px;
+        height: 70%;
 
         @media screen and (max-width: 540px) {
             width: 90%;


### PR DESCRIPTION
This PR fixes the responsiveness issue with the extension iframe that is shown from the Patient Registration for linking external identifiers.
JIRA: https://bahmni.atlassian.net/browse/BAH-4118

Before:
<img width="1163" alt="image" src="https://github.com/user-attachments/assets/2b42d3f3-c077-4deb-bea2-697014f44221">

After:
<img width="1165" alt="image" src="https://github.com/user-attachments/assets/21dc71f1-f101-4042-9d2e-33963f72577c">
