### PR TITLE
Fix incorrect translation key for patient photo capture dialog

### DIFF
--- a/ui/app/common/photo-capture/views/photo.html
+++ b/ui/app/common/photo-capture/views/photo.html
@@ -1,6 +1,6 @@
 <button type="button" class="camera-btn btn" ng-click="launchPhotoCapturePopup()" accesskey="p"></button>
 <button type="button" class="upload-btn btn" ng-click="launchPhotoUploadPopup()" accesskey="u"><i class="fa fa-upload" aria-hidden="true"></i></button>
-<div class="photoCaptureDialog container-fluid" title="{{ 'TAKE_PATIENT_PHOTO_TITTLE'|translate }}">
+<div class="photoCaptureDialog container-fluid" title="{{ 'TAKE_PATIENT_PHOTO_TITLE'|translate }}">
     <div class="row-clear flex">
         <div class="column-wrapper">
             <div class="photo-video-container">

--- a/ui/app/i18n/registration/locale_en.json
+++ b/ui/app/i18n/registration/locale_en.json
@@ -108,6 +108,7 @@
     "BROWSER_DOES_NOT_SUPPORT_VIDEO_TAG_MESSAGE": "Your browser does not support the video tag.",
     "YEARS_LABEL": "Years",
     "TAKE_PATIENT_PHOTO_TITTLE": "Take Patient's Photo",
+    "TAKE_PATIENT_PHOTO_TITLE": "Take Patient's Photo",
     "CLICK_PATIENT_PHOTO_LABEL": "Click Photo",
     "CONFIRM_PATIENT_PHOTO_LABEL": "Confirm Photo",
     "CHOOSE_ANSWER_FROM_DROPDOWN_LABEL": "Choose Answer",


### PR DESCRIPTION
This PR fixes an incorrect translation key used in the patient photo capture dialog.

The UI was displaying the raw translation key due to a typo (`TITTLE` instead of `TITLE`).
A correctly spelled key has been added to the English locale file and the template updated to use it.

This ensures the dialog title renders properly without breaking existing translations.
