### PR TITLE
BAH-2634: Add sortLatestFirst config to obs-to-obs flowsheet display control

### DIFF
--- a/ui/app/common/displaycontrols/tabularview/directives/obsToObsFlowSheet.js
+++ b/ui/app/common/displaycontrols/tabularview/directives/obsToObsFlowSheet.js
@@ -48,6 +48,9 @@ angular.module('bahmni.common.displaycontrol.obsVsObsFlowSheet').directive('obsT
                         if ($scope.config.hideEmptyRecords) {
                             obsInFlowSheet = removeEmptyRecords(obsInFlowSheet);
                         }
+                        if ($scope.config.sortLatestFirst && obsInFlowSheet.rows && obsInFlowSheet.rows.length > 0) {
+                            obsInFlowSheet.rows = obsInFlowSheet.rows.slice().reverse();
+                        }
                         $scope.obsTable = obsInFlowSheet;
                         if (_.isEmpty($scope.obsTable.rows)) {
                             $scope.$emit("no-data-present-event");

--- a/ui/test/unit/common/displaycontrols/obsVsObsFlowSheet/directives/obsToObsFlowSheet.spec.js
+++ b/ui/test/unit/common/displaycontrols/obsVsObsFlowSheet/directives/obsToObsFlowSheet.spec.js
@@ -89,6 +89,120 @@ describe('obsToObsFlowSheet DisplayControl', function () {
 
     });
 
+    describe('sortLatestFirst', function () {
+        it('should reverse the rows when sortLatestFirst is true', function () {
+            var scope = rootScope.$new();
+
+            scope.isOnDashboard = true;
+            scope.section = {
+                "name": "obsToObsFlowSheet",
+                "dashboardConfig": {
+                    "templateName": "TemplateName",
+                    "conceptNames": ["Concept1"],
+                    "sortLatestFirst": true
+                }
+            };
+
+            scope.patient = {
+                "uuid": "patientUuid"
+            };
+
+            var rowsFromServer = [
+                {columns: {"Concept1": [{value: "visit1"}]}},
+                {columns: {"Concept1": [{value: "visit2"}]}},
+                {columns: {"Concept1": [{value: "visit3"}]}}
+            ];
+
+            mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations/flowSheet?conceptNames=Concept1&conceptSet=TemplateName&patientUuid=patientUuid')
+                .respond({headers: [{name: "Concept1"}], rows: rowsFromServer});
+            mockBackend.expectGET('/openmrs/ws/rest/v1/concept?s=byFullySpecifiedName&name=TemplateName&v=custom:(uuid,names,displayString)').respond({results: []});
+
+            var element = compile(simpleHtml)(scope);
+            scope.$digest();
+            mockBackend.flush();
+
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            expect(compiledElementScope.obsTable.rows[0].columns["Concept1"][0].value).toEqual("visit3");
+            expect(compiledElementScope.obsTable.rows[1].columns["Concept1"][0].value).toEqual("visit2");
+            expect(compiledElementScope.obsTable.rows[2].columns["Concept1"][0].value).toEqual("visit1");
+        });
+
+        it('should NOT reverse the rows when sortLatestFirst is false', function () {
+            var scope = rootScope.$new();
+
+            scope.isOnDashboard = true;
+            scope.section = {
+                "name": "obsToObsFlowSheet",
+                "dashboardConfig": {
+                    "templateName": "TemplateName",
+                    "conceptNames": ["Concept1"],
+                    "sortLatestFirst": false
+                }
+            };
+
+            scope.patient = {
+                "uuid": "patientUuid"
+            };
+
+            var rowsFromServer = [
+                {columns: {"Concept1": [{value: "visit1"}]}},
+                {columns: {"Concept1": [{value: "visit2"}]}}
+            ];
+
+            mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations/flowSheet?conceptNames=Concept1&conceptSet=TemplateName&patientUuid=patientUuid')
+                .respond({headers: [{name: "Concept1"}], rows: rowsFromServer});
+            mockBackend.expectGET('/openmrs/ws/rest/v1/concept?s=byFullySpecifiedName&name=TemplateName&v=custom:(uuid,names,displayString)').respond({results: []});
+
+            var element = compile(simpleHtml)(scope);
+            scope.$digest();
+            mockBackend.flush();
+
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            expect(compiledElementScope.obsTable.rows[0].columns["Concept1"][0].value).toEqual("visit1");
+            expect(compiledElementScope.obsTable.rows[1].columns["Concept1"][0].value).toEqual("visit2");
+        });
+
+        it('should NOT reverse the rows when sortLatestFirst is not configured', function () {
+            var scope = rootScope.$new();
+
+            scope.isOnDashboard = true;
+            scope.section = {
+                "name": "obsToObsFlowSheet",
+                "dashboardConfig": {
+                    "templateName": "TemplateName",
+                    "conceptNames": ["Concept1"]
+                }
+            };
+
+            scope.patient = {
+                "uuid": "patientUuid"
+            };
+
+            var rowsFromServer = [
+                {columns: {"Concept1": [{value: "first"}]}},
+                {columns: {"Concept1": [{value: "second"}]}}
+            ];
+
+            mockBackend.expectGET('/openmrs/ws/rest/v1/bahmnicore/observations/flowSheet?conceptNames=Concept1&conceptSet=TemplateName&patientUuid=patientUuid')
+                .respond({headers: [{name: "Concept1"}], rows: rowsFromServer});
+            mockBackend.expectGET('/openmrs/ws/rest/v1/concept?s=byFullySpecifiedName&name=TemplateName&v=custom:(uuid,names,displayString)').respond({results: []});
+
+            var element = compile(simpleHtml)(scope);
+            scope.$digest();
+            mockBackend.flush();
+
+            var compiledElementScope = element.isolateScope();
+            scope.$digest();
+
+            expect(compiledElementScope.obsTable.rows[0].columns["Concept1"][0].value).toEqual("first");
+            expect(compiledElementScope.obsTable.rows[1].columns["Concept1"][0].value).toEqual("second");
+        });
+    });
+
     describe('getHeaderName ', function () {
         it('should return the concept name when there is no abbreviation and there is no short name and units not specified', function () {
             var scope = rootScope.$new();
@@ -930,4 +1044,3 @@ describe('obsToObsFlowSheet DisplayControl', function () {
         });
     })
 });
-


### PR DESCRIPTION
## Summary

Introduces a `sortLatestFirst` boolean config option for the obs-to-obs flowsheet display control. When set to `true`, observation rows are reversed after the API response so the most recent entries appear at the top of the table.

## Changes

### `ui/app/common/displaycontrols/tabularview/directives/obsToObsFlowSheet.js`
- After `getObsInFlowSheet` API response, if `$scope.config.sortLatestFirst` is truthy and rows exist, reverse `obsInFlowSheet.rows` using `.slice().reverse()` (non-mutating copy-then-reverse to avoid side effects)

### `ui/test/unit/common/displaycontrols/obsVsObsFlowSheet/directives/obsToObsFlowSheet.spec.js`
- Added 3 new test cases under `describe('sortLatestFirst')`:
  - `sortLatestFirst: true` → rows appear in reversed order
  - `sortLatestFirst: false` → rows appear in original server order
  - `sortLatestFirst` not configured → rows appear in original server order

## Usage (in dashboard/expanded config JSON)

```json
{
  "type": "obsVsObsFlowSheet",
  "dashboardConfig": {
    "templateName": "Vitals",
    "conceptNames": ["Weight", "Height"],
    "sortLatestFirst": true
  }
}
```

## Acceptance Criteria

- ✅ Introducing a config to display the obs sorted by latest first

## Jira
https://bahmni.atlassian.net/browse/BAH-2634