### PR TITLE
BAH-2345: Fix Create New button unresponsive after ABHA verification

### DIFF
--- a/ui/app/registration/controllers/patientCommonController.js
+++ b/ui/app/registration/controllers/patientCommonController.js
@@ -36,7 +36,10 @@ angular.module('bahmni.registration')
                 var iframe = $document[0].getElementById("extension-popup");
                 iframe.src = getExtensionPoint(identifierType).src + "?action=" + action;
                 $scope.showExtIframe = true;
-                $window.addEventListener("message", function (popupWindowData) {
+
+                function handlePopupMessage(popupWindowData) {
+                    // Remove this one-shot listener immediately so it never fires twice
+                    $window.removeEventListener("message", handlePopupMessage, false);
                     if (popupWindowData.data.patient !== undefined) {
                         $rootScope.extenstionPatient = popupWindowData.data.patient;
                         if ($rootScope.extenstionPatient.id !== undefined) {
@@ -46,12 +49,20 @@ angular.module('bahmni.registration')
                             }
                         } else $window.open(Bahmni.Registration.Constants.newPatient, "_self");
                         $scope.updateInfoFromExtSource($rootScope.extenstionPatient);
+                        $rootScope.extenstionPatient = undefined;
                         $scope.$digest();
                     }
                     if (popupWindowData.data.patientUuid !== undefined) {
                         $window.open(Bahmni.Registration.Constants.existingPatient + popupWindowData.data.patientUuid, "_self");
                     }
-                }, false);
+                }
+
+                $window.addEventListener("message", handlePopupMessage, false);
+
+                // Cleanup if the scope is destroyed before the popup message arrives
+                $scope.$on('$destroy', function () {
+                    $window.removeEventListener("message", handlePopupMessage, false);
+                });
             };
 
             $scope.isDisabledAttribute = function (attribute) {
@@ -435,4 +446,3 @@ angular.module('bahmni.registration')
                 return ($scope.patient.causeOfDeath || $scope.patient.deathDate) && $scope.patient.dead;
             };
         }]);
-


### PR DESCRIPTION
## Summary

Fixes a bug where the "Create New" button becomes unresponsive after saving a patient via ABHA verification in the Registration module.

## Root Cause

In `patientCommonController.js`, `openIdentifierPopup` called `$window.addEventListener("message", ...)` using an **anonymous inline function** that was **never removed**. This caused a listener leak with two consequences:

1. **Multiple handlers accumulated** — every call to `openIdentifierPopup` added a new handler. On a second ABHA verification (or any subsequent `postMessage` event from any source), multiple old handlers fired simultaneously, each calling `$window.open(...)` with potentially conflicting URLs, corrupting the navigation state.

2. **Stale scope reference** — After Angular transitioned from the new-patient form to the edit page (following patient save), the old listener still referenced the old, destroyed `$scope`. When the user clicked "Create New" and navigated back, the stale listener could call `updateInfoFromExtSource` on the dead scope or trigger `$window.open` again, preventing clean navigation.

## Fix

- **Named function `handlePopupMessage`**: refactored the anonymous handler to a named function so it can be passed to `removeEventListener`
- **Self-removing (one-shot)**: the handler calls `$window.removeEventListener("message", handlePopupMessage, false)` as its very first line, ensuring it fires at most once per popup open
- **Scope-destroy cleanup**: registered `$scope.$on('$destroy', ...)` to remove the listener if the Angular controller is destroyed before any popup message arrives (e.g. user navigates away from the page while popup is open)
- **Clear `$rootScope.extenstionPatient` after use**: set `$rootScope.extenstionPatient = undefined` immediately after `updateInfoFromExtSource` processes it, preventing stale ABHA data from being re-applied on the next controller instantiation

## Changes

- `ui/app/registration/controllers/patientCommonController.js` — refactored `openIdentifierPopup` event listener management

## Testing

1. Open Registration, click "Create New"
2. Open ABHA verification, complete it
3. Save the new patient → navigates to edit page
4. Click "Create New" in the navigation header
5. Expected: navigates to fresh new patient form ✅
6. Previous: nothing happened (button appeared dead) ❌

## Jira
https://bahmni.atlassian.net/browse/BAH-2345