### PR TITLE
BAH-4739 | Add ml/kg and mcg/kg dosage rules with infusion parameters

### DIFF
--- a/ui/app/clinical/common/models/drugOrder.js
+++ b/ui/app/clinical/common/models/drugOrder.js
@@ -26,6 +26,8 @@ Bahmni.Clinical.DrugOrder = (function () {
             var dosingInstructions = {};
             dosingInstructions.instructions = drugOrderData.instructions && drugOrderData.instructions;
             dosingInstructions.additionalInstructions = drugOrderData.additionalInstructions;
+            dosingInstructions.rate = drugOrderData.rate || null;
+            dosingInstructions.additives = drugOrderData.additives || null;
             if (drugOrderData.frequencyType === Bahmni.Clinical.Constants.dosingTypes.variable) {
                 dosingInstructions.morningDose = drugOrderData.variableDosingType.morningDose;
                 dosingInstructions.afternoonDose = drugOrderData.variableDosingType.afternoonDose;

--- a/ui/app/clinical/common/models/drugOrderViewModel.js
+++ b/ui/app/clinical/common/models/drugOrderViewModel.js
@@ -733,6 +733,8 @@ Bahmni.Clinical.DrugOrderViewModel.createFromContract = function (drugOrderRespo
     }
     viewModel.instructions = administrationInstructions.instructions;
     viewModel.additionalInstructions = administrationInstructions.additionalInstructions;
+    viewModel.rate = administrationInstructions.rate;
+    viewModel.additives = administrationInstructions.additives;
     viewModel.quantity = drugOrderResponse.dosingInstructions.quantity;
     viewModel.quantityUnit = drugOrderResponse.dosingInstructions.quantityUnits;
     viewModel.drug = drugOrderResponse.drug;

--- a/ui/app/clinical/consultation/controllers/addTreatmentController.js
+++ b/ui/app/clinical/consultation/controllers/addTreatmentController.js
@@ -383,7 +383,8 @@ angular.module('bahmni.clinical')
             $scope.calculateDose = function (treatment) {
                 if (treatment.dosingRule != null || treatment.dosingRule != undefined) {
                     var visitUuid = treatmentConfig.orderSet.calculateDoseOnlyOnCurrentVisitValues ? $scope.activeVisit.uuid : undefined;
-                    var calculatedDose = orderSetService.getCalculatedDose($scope.patient.uuid, treatment.drug.name, treatment.uniformDosingType.dose, treatment.uniformDosingType.doseUnits, '', treatment.dosingRule, visitUuid);
+                    var drugName = treatment.drug ? treatment.drug.name : treatment.drugNonCoded;
+                    var calculatedDose = orderSetService.getCalculatedDose($scope.patient.uuid, drugName, treatment.uniformDosingType.dose, treatment.uniformDosingType.doseUnits, '', treatment.dosingRule, visitUuid);
                     treatment.dosingRule = undefined;
                     calculatedDose.then(function (calculatedDosage) {
                         treatment.uniformDosingType.dose = calculatedDosage.dose;
@@ -912,6 +913,21 @@ angular.module('bahmni.clinical')
                 }
             };
 
+            var setRuleUnitsMap = function (medicationConfig) {
+                $scope.ruleUnitsMap = {};
+                if (medicationConfig && medicationConfig.tabConfig && medicationConfig.tabConfig.allMedicationTabConfig
+                    && medicationConfig.tabConfig.allMedicationTabConfig.orderSet) {
+                    $scope.ruleUnitsMap = medicationConfig.tabConfig.allMedicationTabConfig.orderSet.dosageRuleUnitsMap || {};
+                }
+                $scope.$watch('treatment.dosingRule', function (newRule) {
+                    if (!newRule) return;
+                    var ruleUnits = $scope.ruleUnitsMap[newRule];
+                    if (ruleUnits && ruleUnits.length === 1) {
+                        $scope.treatment.uniformDosingType.doseUnits = ruleUnits[0];
+                    }
+                });
+            };
+
             $scope.verifyAdd = function (treatment) {
                 if (!$scope.addTreatmentWithPatientWeight.hasOwnProperty('duration') && !$scope.addTreatmentWithDiagnosis.hasOwnProperty('order')) {
                     return $scope.addForm.$valid && $scope.calculateDose(treatment);
@@ -975,6 +991,7 @@ angular.module('bahmni.clinical')
                 }
                 $scope.addToNewTreatment = true;
                 showRulesInMedication(medicationConfig);
+                setRuleUnitsMap(medicationConfig);
                 setContinuousMedicationRoutes(medicationConfig);
             };
             init();

--- a/ui/app/clinical/consultation/views/newDrugOrders.html
+++ b/ui/app/clinical/consultation/views/newDrugOrders.html
@@ -72,6 +72,8 @@
                 <div ng-if="newTreatment.additionalInstructions">
                      | {{newTreatment.additionalInstructions}}
                 </div>
+                <div ng-if="newTreatment.rate"> | {{newTreatment.rate}} ml/hr</div>
+                <div ng-if="newTreatment.additives"> | {{newTreatment.additives}}</div>
                 <div ng-if="newTreatment.getQuantityWithUnit()"> | {{newTreatment.getQuantityWithUnit()}}</div>
                 <div>
                     <span ng-show="allMedicinesInPrescriptionAvailableForIPD && newTreatment.careSetting==='INPATIENT'"> | {{ ::'IPD_BUTTON' | translate}}</span>

--- a/ui/app/clinical/consultation/views/treatmentSections/addTreatment.html
+++ b/ui/app/clinical/consultation/views/treatmentSections/addTreatment.html
@@ -275,6 +275,25 @@
                     </div>
                 </article>
 
+                <article class="form-field" ng-if="treatment.dosingRule === 'ml/kg'">
+                    <div class="field-attribute">
+                        <label class="start-date-label fl">{{::treatmentConfig.translate('rate', 'MEDICATION_LABEL_RATE')}}</label>
+                    </div>
+                    <div class="field-value">
+                        <input type="number" id="infusion-rate" class="drug-order-notes"
+                               ng-model="treatment.rate" min="0"/>
+                    </div>
+                </article>
+
+                <article class="form-field" ng-if="treatment.dosingRule === 'ml/kg'">
+                    <div class="field-attribute">
+                        <label class="start-date-label fl">{{::treatmentConfig.translate('additives', 'MEDICATION_LABEL_ADDITIVES')}}</label>
+                    </div>
+                    <div class="field-value">
+                        <textarea id="infusion-additives" rows="1" msd-elastic class="drug-order-notes"
+                                  ng-model="treatment.additives"/>
+                    </div>
+                </article>
 
                 <div class="operations fr clearfix">
                     <button class="add-drug-btn secondary-button fl" type="submit" accesskey="{{ ::treatmentConfig.translate('addAccessKey', 'MEDICATION_ADD_ACCESS_KEY') }}"

--- a/ui/app/clinical/consultation/views/treatmentSections/addTreatment.html
+++ b/ui/app/clinical/consultation/views/treatmentSections/addTreatment.html
@@ -275,7 +275,7 @@
                     </div>
                 </article>
 
-                <div ng-if="treatment.dosingRule === 'ml/kg'">
+                <div ng-if="treatment.doseUnits === 'ml'">
                     <article class="form-field">
                         <div class="field-attribute">
                             <label class="start-date-label fl">{{::treatmentConfig.translate('rate', 'MEDICATION_LABEL_RATE')}}</label>

--- a/ui/app/clinical/consultation/views/treatmentSections/addTreatment.html
+++ b/ui/app/clinical/consultation/views/treatmentSections/addTreatment.html
@@ -275,25 +275,27 @@
                     </div>
                 </article>
 
-                <article class="form-field" ng-if="treatment.dosingRule === 'ml/kg'">
-                    <div class="field-attribute">
-                        <label class="start-date-label fl">{{::treatmentConfig.translate('rate', 'MEDICATION_LABEL_RATE')}}</label>
-                    </div>
-                    <div class="field-value">
-                        <input type="number" id="infusion-rate" class="drug-order-notes"
-                               ng-model="treatment.rate" min="0"/>
-                    </div>
-                </article>
+                <div ng-if="treatment.dosingRule === 'ml/kg'">
+                    <article class="form-field">
+                        <div class="field-attribute">
+                            <label class="start-date-label fl">{{::treatmentConfig.translate('rate', 'MEDICATION_LABEL_RATE')}}</label>
+                        </div>
+                        <div class="field-value">
+                            <input type="number" id="infusion-rate" class="drug-order-notes"
+                                   ng-model="treatment.rate" min="0"/>
+                        </div>
+                    </article>
 
-                <article class="form-field" ng-if="treatment.dosingRule === 'ml/kg'">
-                    <div class="field-attribute">
-                        <label class="start-date-label fl">{{::treatmentConfig.translate('additives', 'MEDICATION_LABEL_ADDITIVES')}}</label>
-                    </div>
-                    <div class="field-value">
-                        <textarea id="infusion-additives" rows="1" msd-elastic class="drug-order-notes"
-                                  ng-model="treatment.additives"/>
-                    </div>
-                </article>
+                    <article class="form-field">
+                        <div class="field-attribute">
+                            <label class="start-date-label fl">{{::treatmentConfig.translate('additives', 'MEDICATION_LABEL_ADDITIVES')}}</label>
+                        </div>
+                        <div class="field-value">
+                            <textarea id="infusion-additives" rows="1" msd-elastic class="drug-order-notes"
+                                      ng-model="treatment.additives"/>
+                        </div>
+                    </article>
+                </div>
 
                 <div class="operations fr clearfix">
                     <button class="add-drug-btn secondary-button fl" type="submit" accesskey="{{ ::treatmentConfig.translate('addAccessKey', 'MEDICATION_ADD_ACCESS_KEY') }}"

--- a/ui/app/clinical/consultation/views/treatmentSections/addTreatment.html
+++ b/ui/app/clinical/consultation/views/treatmentSections/addTreatment.html
@@ -95,7 +95,8 @@
                                     <select id="uniform-dose-unit" class="form-field freq-choose-units" ng-model="treatment.uniformDosingType.doseUnits"
                                             ng-options="item.name as item.name for item in getFinalDosingUnits(treatment)"
                                             ng-required="treatment.isUniformDoseUnitRequired()"
-                                            ng-class="{'noFractionOptions' : !isDoseFractionsAvailable()}">
+                                            ng-class="{'noFractionOptions' : !isDoseFractionsAvailable()}"
+                                            ng-disabled="isRuleMode(treatment)">
                                         <option value="">{{ ::treatmentConfig.translate('doseUnitsPlaceHolder', 'MEDICATION_DOSE_UNIT_PLACEHOLDER') }} </option>
                                     </select>
                                 </div>

--- a/ui/app/clinical/consultation/views/treatmentSections/drugOrderHistory.html
+++ b/ui/app/clinical/consultation/views/treatmentSections/drugOrderHistory.html
@@ -84,6 +84,8 @@
                                         {{drugOrder.instructions}}
                                     </div>
                                     <div ng-if="drugOrder.additionalInstructions"> | {{drugOrder.additionalInstructions}}</div>
+                                    <div ng-if="drugOrder.rate"> | {{drugOrder.rate}} ml/hr</div>
+                                    <div ng-if="drugOrder.additives"> | {{drugOrder.additives}}</div>
                                     <div ng-if="drugOrder.getQuantityWithUnit()"> | {{drugOrder.getQuantityWithUnit()}}</div>
                                     <div>
                                         <span ng-show="allMedicinesInPrescriptionAvailableForIPD && drugOrder.careSetting==='INPATIENT'"> | {{ ::'IPD_BUTTON' | translate}}</span>

--- a/ui/app/clinical/displaycontrols/treatmentData/views/treatmentTableRow.html
+++ b/ui/app/clinical/displaycontrols/treatmentData/views/treatmentTableRow.html
@@ -9,6 +9,8 @@
         <span ng-if="::(params.showRoute == true)" ng-class="::{'strike-text':drugOrder.isDiscontinuedOrStopped()}">{{::drugOrder.getDescriptionWithoutDuration()}}</span>
         <span ng-if="::!(params.showRoute == true)" ng-class="::{'strike-text':drugOrder.isDiscontinuedOrStopped()}">{{::drugOrder.getDescriptionWithoutRouteAndDuration()}}</span>
         <span>{{::drugOrder.getSpanDetails()}}</span>
+        <span ng-if="::drugOrder.rate">, {{::drugOrder.rate}} ml/hr</span>
+        <span ng-if="::drugOrder.additives">, {{::drugOrder.additives}}</span>
         <span ng-if="::drugOrder.isDiscontinuedOrStopped()" ng-class="::{'discontinued-text':drugOrder.isDiscontinuedOrStopped()}">{{'MEDICATION_STOPPED_ON'|translate}} {{::drugOrder.effectiveStopDate | bahmniDate}}</span>
     </td>
     <td class="days" ng-if="::(!params.hideVisitDate)">

--- a/ui/test/unit/clinical/controllers/addTreatmentController.spec.js
+++ b/ui/test/unit/clinical/controllers/addTreatmentController.spec.js
@@ -31,7 +31,8 @@ describe("AddTreatmentController", function () {
                     "calculateDoseOnlyOnCurrentVisitValues": false,
                     "showRulesInMedication": true,
                     "dosageRuleUnitsMap": {
-                        "mg/kg": ["mg", "ml"]
+                        "mg/kg": ["mg", "ml"],
+                        "mcg/kg": ["mcg"]
                     }
                 }
             }
@@ -2231,6 +2232,29 @@ describe("AddTreatmentController", function () {
             var drugOrder1 = Bahmni.Clinical.DrugOrderViewModel.createFromContract(activeDrugOrder);
             drugOrder1.dosingRule = null;
             expect(scope.isRuleMode(drugOrder1)).toBeFalsy();
+        });
+    });
+
+    describe('ruleUnitsMap initialization', function () {
+        it('should initialize ruleUnitsMap from medicationConfig dosageRuleUnitsMap', function () {
+            expect(scope.ruleUnitsMap).toBeDefined();
+            expect(scope.ruleUnitsMap['mcg/kg']).toEqual(['mcg']);
+            expect(scope.ruleUnitsMap['mg/kg']).toEqual(['mg', 'ml']);
+        });
+    });
+
+    describe('auto-populate dose unit on dosing rule selection', function () {
+        it('should auto-populate doseUnits to mcg when mcg/kg rule is selected', function () {
+            scope.treatment.dosingRule = 'mcg/kg';
+            scope.$digest();
+            expect(scope.treatment.uniformDosingType.doseUnits).toEqual('mcg');
+        });
+
+        it('should not auto-populate doseUnits when rule has multiple units', function () {
+            var previousDoseUnit = scope.treatment.uniformDosingType.doseUnits;
+            scope.treatment.dosingRule = 'mg/kg';
+            scope.$digest();
+            expect(scope.treatment.uniformDosingType.doseUnits).toEqual(previousDoseUnit);
         });
     });
 

--- a/ui/test/unit/clinical/models/drugOrder.spec.js
+++ b/ui/test/unit/clinical/models/drugOrder.spec.js
@@ -142,5 +142,88 @@ describe("DrugOrder", function() {
 			expect(drugOrder.duration).toBe(uiDrugObject.duration);
 			expect(drugOrder.durationUnits).toBe(uiDrugObject.durationUnit);
 		});
+
+		it("should serialize ml/kg dosing rule with rate and additives", function() {
+			var uiDrugObject = {
+				asNeeded: false,
+				autoExpireDate: undefined,
+				doseUnits: "ml",
+				dosingInstructionType: "org.openmrs.module.bahmniemrapi.drugorder.dosinginstructions.FlexibleDosingInstructions",
+				drugNameDisplay: "Normal Saline 0.9% IV Fluid",
+				drugNonCoded: "Normal Saline 0.9% IV Fluid",
+				duration: 7,
+				durationInDays: 7,
+				durationUnit: "Day(s)",
+				frequencyType: "uniform",
+				instructions: "For IV infusion",
+				additionalInstructions: "Monitor vitals every 4 hours",
+				rate: 100,
+				additives: "10 mEq KCl in saline",
+				quantity: 700,
+				quantityUnit: "ml",
+				route: "Intravenous",
+				scheduledDate: null,
+				uniformDosingType: {
+					dose: 100,
+					doseUnits: "ml",
+					frequency: "Once a day"
+				},
+				effectiveStartDate: '2014-04-10T15:52:59.000+0530',
+				effectiveStopDate: '2014-04-17T15:52:59.000+0530',
+				dosingRule: "ml/kg",
+				isUniformDosingType: function() {
+					return true;
+				},
+				isCurrentDosingTypeEmpty: function() {
+					return false;
+				}
+			};
+			var drugOrder = Bahmni.Clinical.DrugOrder.createFromUIObject(uiDrugObject);
+
+			var administrationInstructions = JSON.parse(drugOrder.dosingInstructions.administrationInstructions);
+			expect(administrationInstructions.rate).toBe(100);
+			expect(administrationInstructions.additives).toBe("10 mEq KCl in saline");
+			expect(administrationInstructions.instructions).toBe("For IV infusion");
+			expect(administrationInstructions.additionalInstructions).toBe("Monitor vitals every 4 hours");
+		});
+
+		it("should serialize rate as null when not provided", function() {
+			var uiDrugObject = {
+				asNeeded: false,
+				doseUnits: "Tablet(s)",
+				dosingInstructionType: "org.openmrs.module.bahmniemrapi.drugorder.dosinginstructions.FlexibleDosingInstructions",
+				drugNameDisplay: "Paracetamol 500mg",
+				drugNonCoded: "Paracetamol 500mg",
+				duration: 5,
+				durationInDays: 5,
+				durationUnit: "Day(s)",
+				frequencyType: "uniform",
+				instructions: "Take with water",
+				additionalInstructions: null,
+				rate: null,
+				additives: null,
+				quantity: 5,
+				quantityUnit: "Tablet(s)",
+				route: "Orally",
+				uniformDosingType: {
+					dose: 1,
+					doseUnits: "Tablet(s)",
+					frequency: "Three times a day"
+				},
+				effectiveStartDate: '2014-04-10T15:52:59.000+0530',
+				effectiveStopDate: '2014-04-15T15:52:59.000+0530',
+				isUniformDosingType: function() {
+					return true;
+				},
+				isCurrentDosingTypeEmpty: function() {
+					return false;
+				}
+			};
+			var drugOrder = Bahmni.Clinical.DrugOrder.createFromUIObject(uiDrugObject);
+
+			var administrationInstructions = JSON.parse(drugOrder.dosingInstructions.administrationInstructions);
+			expect(administrationInstructions.rate).toBe(null);
+			expect(administrationInstructions.additives).toBe(null);
+		});
 	});
 });

--- a/ui/test/unit/clinical/models/drugOrderViewModel.spec.js
+++ b/ui/test/unit/clinical/models/drugOrderViewModel.spec.js
@@ -736,6 +736,81 @@ describe("drugOrderViewModel", function () {
             expect(drugOrderViewModel.reverseSynced).toBe(true);
         });
 
+        it("should deserialize rate and additives from administrationInstructions JSON", function() {
+            var drugOrder = {
+                "uuid": "ml-kg-order-uuid",
+                "action": "NEW",
+                "careSetting": "Inpatient",
+                "orderType": "Drug Order",
+                "drug": {
+                    "form": "Fluid",
+                    "uuid": "8d7e3dc0-f4ad-400c-9468-5a9e2b1f4240",
+                    "name": "Normal Saline 0.9% IV Fluid"
+                },
+                "dosingInstructions": {
+                    "quantity": 700,
+                    "route": "Intravenous",
+                    "frequency": "Once a day",
+                    "doseUnits": "ml",
+                    "asNeeded": false,
+                    "quantityUnits": "ml",
+                    "dose": 100,
+                    "administrationInstructions": "{\"instructions\":\"For IV infusion\",\"additionalInstructions\":\"Monitor vitals every 4 hours\",\"rate\":100,\"additives\":\"10 mEq KCl in saline\"}",
+                    "numberOfRefills": null
+                },
+                "durationUnits": "Days",
+                "dateActivated": 1410322624000,
+                "effectiveStartDate": 1410322624000,
+                "effectiveStopDate": 1410409024000,
+                "duration": 7,
+                "provider": {name: "Dr. Smith"},
+                "orderAttributes": []
+            };
+            var drugOrderViewModel = Bahmni.Clinical.DrugOrderViewModel.createFromContract(drugOrder);
+
+            expect(drugOrderViewModel.rate).toBe(100);
+            expect(drugOrderViewModel.additives).toBe("10 mEq KCl in saline");
+            expect(drugOrderViewModel.instructions).toBe("For IV infusion");
+            expect(drugOrderViewModel.additionalInstructions).toBe("Monitor vitals every 4 hours");
+        });
+
+        it("should deserialize rate and additives as null when not present in administrationInstructions", function() {
+            var drugOrder = {
+                "uuid": "order-uuid",
+                "action": "NEW",
+                "careSetting": "Outpatient",
+                "orderType": "Drug Order",
+                "drug": {
+                    "form": "Tablet",
+                    "uuid": "8d7e3dc0-f4ad-400c-9468-5a9e2b1f4230",
+                    "name": "Paracetamol 500mg"
+                },
+                "dosingInstructions": {
+                    "quantity": 15,
+                    "route": "Orally",
+                    "frequency": "Three times a day",
+                    "doseUnits": "Tablet",
+                    "asNeeded": false,
+                    "quantityUnits": "Tablet",
+                    "dose": 1,
+                    "administrationInstructions": "{\"instructions\":\"Take with water\",\"additionalInstructions\":null}",
+                    "numberOfRefills": null
+                },
+                "durationUnits": "Days",
+                "dateActivated": 1410322624000,
+                "effectiveStartDate": 1410322624000,
+                "duration": 5,
+                "provider": {name: "Dr. Johnson"},
+                "orderAttributes": []
+            };
+            var drugOrderViewModel = Bahmni.Clinical.DrugOrderViewModel.createFromContract(drugOrder);
+
+            expect(drugOrderViewModel.rate).toBeUndefined();
+            expect(drugOrderViewModel.additives).toBeUndefined();
+            expect(drugOrderViewModel.instructions).toBe("Take with water");
+            expect(drugOrderViewModel.additionalInstructions).toBe(null);
+        });
+
 
     });
 


### PR DESCRIPTION
**Description:**

  **Summary**

  - Added ml/kg and mcg/kg as selectable options in the Dosage Rule dropdown in the Medication tab
  - Auto-populates Dose Unit to ml when ml/kg is selected (unit locked); auto-populates mcg when mcg/kg is selected
  - Displays Rate (ml/hr) and Additives fields dynamically when ml/kg is selected; hidden for all other rules
  - Persists Rate and Additives as part of the drug order's additional instructions
  - Displays Rate and Additives in the treatment history row and drug order history views

  **Test plan**

  - Select ml/kg — verify Dose Unit locks to ml and Rate/Additives fields appear
  - Select mcg/kg — verify Dose Unit auto-populates to mcg
  - Select any other rule — verify Rate/Additives fields are hidden
  - Save a prescription with Rate and Additives — verify values persist and display correctly in treatment history
  - Verify calculated dose = Dose Value × Latest Patient Weight