### PR TITLE
BAH-4708 | Apply Alpine package upgrades in Dockerfile

### DIFF
--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM httpd:2.4-alpine
 
+RUN apk --no-cache upgrade
+
 EXPOSE 8091
 COPY package/docker/httpd.conf /usr/local/apache2/conf
 COPY package/docker/systemdate.sh /usr/local/apache2/cgi-bin/systemdate


### PR DESCRIPTION
## Summary
- Add `RUN apk --no-cache upgrade` to `package/docker/Dockerfile` so the `httpd:2.4-alpine` base image picks up the latest Alpine security patches at build time.

## Test plan
- [ ] `docker build -f package/docker/Dockerfile .` completes successfully
- [ ] Resulting image starts and serves on port 8091 as before
- [ ] Verify package patches are applied (e.g. `apk info -v` inside the built image vs. base)