### PR TITLE
BAH-4733 New Home for All, Privilege-Gated Old Registration Tile and …

### DIFF
--- a/ui/app/admin/app.js
+++ b/ui/app/admin/app.js
@@ -18,7 +18,7 @@ angular.module('admin')
                 templateUrl: 'views/adminDashboard.html',
                 controller: 'AdminDashboardController',
                 data: {
-                    backLinks: [{label: "Home", accessKey: "h", url: "../home/", icon: "fa-home"}],
+                    backLinks: [{label: "Home", accessKey: "h", url: "/bahmni/home/", icon: "fa-home"}],
                     extensionPointId: 'org.bahmni.admin.dashboard'
                 }
             }).state('admin.csv', {

--- a/ui/app/adt/app.js
+++ b/ui/app/adt/app.js
@@ -8,7 +8,7 @@ angular.module('adt', ['bahmni.common.patient', 'bahmni.common.patientSearch', '
 angular.module('adt').config(['$stateProvider', '$httpProvider', '$urlRouterProvider', '$bahmniTranslateProvider', '$compileProvider',
     function ($stateProvider, $httpProvider, $urlRouterProvider, $bahmniTranslateProvider, $compileProvider) {
         $urlRouterProvider.otherwise('/home');
-        var homeBackLink = {label: "", url: "../home/", accessKey: "h", icon: "fa-home", id: "homeBackLink"};
+        var homeBackLink = {label: "", url: "/bahmni/home/", accessKey: "h", icon: "fa-home", id: "homeBackLink"};
         var adtHomeBackLink = {label: "", url: "#/home", accessKey: "p", icon: "fa-users", id: "adtHomeBackLink" };
 
     // @if DEBUG='production'

--- a/ui/app/adt/constants.js
+++ b/ui/app/adt/constants.js
@@ -8,7 +8,7 @@ Bahmni.ADT.Constants = (function () {
         patientsListUrl: "/patient/search",
         ipdDashboardUrl: "#/patient/{{patientUuid}}/visit/{{visitUuid}}/",
         admissionLocationUrl: "/openmrs/ws/rest/v1/admissionLocation/",
-        mfeIpdDashboardUrl: Bahmni.Common.Constants.hostURL + '/bahmni/clinical/#/default/patient/{{patientUuid}}/dashboard/visit/ipd/{{visitUuid}}?source=adt'
+        mfeIpdDashboardUrl: Bahmni.Common.Constants.hostURL + '/bahmni/v1/clinical/#/default/patient/{{patientUuid}}/dashboard/visit/ipd/{{visitUuid}}?source=adt'
     };
 })();
 

--- a/ui/app/adt/controllers/careViewController.js
+++ b/ui/app/adt/controllers/careViewController.js
@@ -24,7 +24,7 @@ angular.module('bahmni.adt')
             auditLogService.log(undefined, 'USER_LOGOUT_SUCCESS', undefined, 'MODULE_LABEL_LOGOUT_KEY').then(function () {
                 sessionService.destroy().then(
                     function () {
-                        $window.location = "../home/index.html#/login";
+                        $window.location = "/bahmni/home/index.html#/login";
                     });
             });
         },

--- a/ui/app/adt/index.html
+++ b/ui/app/adt/index.html
@@ -238,7 +238,7 @@
         <script src="../common/i18n/services/mergeLocaleFilesService.js"></script>
         <script src="../common/ui-helper/directives/singleClick.js"></script>
         <script src="../common/util/translationUtil.js"></script>
-        <script src="../clinical/consultation/mappers/consultationMapper.js"></script>
+        <script src="/bahmni/v1/clinical/consultation/mappers/consultationMapper.js"></script>
 
         <script src="init.js"></script> 
         <script src="constants.js"></script>

--- a/ui/app/bedmanagement/app.js
+++ b/ui/app/bedmanagement/app.js
@@ -9,7 +9,7 @@ angular.module('ipd').config(['$stateProvider', '$httpProvider', '$urlRouterProv
     function ($stateProvider, $httpProvider, $urlRouterProvider, $bahmniTranslateProvider, $compileProvider) {
         $urlRouterProvider.otherwise('/home');
 
-        var homeBackLink = {type: "link", name: "Home", value: "../home/", accessKey: "h", icon: "fa-home"};
+        var homeBackLink = {type: "link", name: "Home", value: "/bahmni/home/", accessKey: "h", icon: "fa-home"};
         var admitLink = {type: "state", name: "ADMIT_HOME_KEY", value: "home", accessKey: "a"};
         var bedManagementLink = {type: "state", name: "BED_MANAGEMENT_KEY", value: "bedManagement", accessKey: "b"};
         var navigationLinks = [admitLink, bedManagementLink];

--- a/ui/app/bedmanagement/controllers/careViewController.js
+++ b/ui/app/bedmanagement/controllers/careViewController.js
@@ -24,7 +24,7 @@ angular.module('bahmni.ipd')
             auditLogService.log(undefined, 'USER_LOGOUT_SUCCESS', undefined, 'MODULE_LABEL_LOGOUT_KEY').then(function () {
                 sessionService.destroy().then(
                     function () {
-                        $window.location = "../home/index.html#/login";
+                        $window.location = "/bahmni/home/index.html#/login";
                     });
             });
         },

--- a/ui/app/bedmanagement/index.html
+++ b/ui/app/bedmanagement/index.html
@@ -238,7 +238,7 @@
 <script src="../common/services/formPrintService.js"></script>
 <script src="../common/services/allergyService.js"></script>
 <script src="../common/logging/services/auditLogService.js"></script>
-<script src="../clinical/consultation/mappers/consultationMapper.js"></script>
+<script src="/bahmni/v1/clinical/consultation/mappers/consultationMapper.js"></script>
 
 <script src="init.js"></script>
 <script src="constants.js"></script>

--- a/ui/app/clinical/app.js
+++ b/ui/app/clinical/app.js
@@ -28,7 +28,7 @@ angular.module('consultation')
                 id: "patients-link",
                 icon: "fa-users"
             };
-            var homeBackLink = {label: "", url: "../home/index.html", accessKey: "h", icon: "fa-home"};
+            var homeBackLink = {label: "", url: "/bahmni/home/index.html", accessKey: "h", icon: "fa-home"};
 
         // @if DEBUG='production'
             $compileProvider.debugInfoEnabled(false);
@@ -69,7 +69,7 @@ angular.module('consultation')
                 },
                 resolve: {
                     initializeConfigs: function (initialization, $stateParams) {
-                        $stateParams.configName = $stateParams.configName || Bahmni.Clinical.Constants.defaultExtensionName;
+                        $stateParams.configName = ($stateParams.configName && $stateParams.configName !== 'default') ? $stateParams.configName : Bahmni.Clinical.Constants.defaultExtensionName;
                         patientSearchBackLink.state = 'search.patientsearch({configName: \"' + $stateParams.configName + '\"})';
                         return initialization($stateParams.configName);
                     }
@@ -91,7 +91,7 @@ angular.module('consultation')
                 },
                 resolve: {
                     initialization: function (initialization, $stateParams) {
-                        $stateParams.configName = $stateParams.configName || Bahmni.Clinical.Constants.defaultExtensionName;
+                        $stateParams.configName = ($stateParams.configName && $stateParams.configName !== 'default') ? $stateParams.configName : Bahmni.Clinical.Constants.defaultExtensionName;
                         patientSearchBackLink.state = 'search.patientsearch({configName: \"' + $stateParams.configName + '\"})';
                         return initialization($stateParams.configName);
                     },

--- a/ui/app/clinical/common/controllers/visitController.js
+++ b/ui/app/clinical/common/controllers/visitController.js
@@ -54,7 +54,7 @@ angular.module('bahmni.clinical')
                         auditLogService.log(undefined, 'USER_LOGOUT_SUCCESS', undefined, 'MODULE_LABEL_LOGOUT_KEY').then(function () {
                             sessionService.destroy().then(
                                 function () {
-                                    $window.location = "../home/index.html#/login";
+                                    $window.location = "/bahmni/home/index.html#/login";
                                 });
                         });
                     },

--- a/ui/app/clinical/common/views/mobileHeader.html
+++ b/ui/app/clinical/common/views/mobileHeader.html
@@ -32,13 +32,13 @@
         <recent-patients></recent-patients>
         <ul class="menu-list">
             <li class="menu-item">
-                <a href="../home/index.html">
+                <a href="/bahmni/home/index.html">
                     <i class="fa fa-home"></i>
                     <span>{{"BAHMNI_HOME_TRANSLATION_KEY"| translate}}</span>
                 </a>
             </li>
             <li class="menu-item">
-                <a href="#/default/patient/search">
+                <a href="#/v2/patient/search">
                     <i class="fa fa-group"></i>
                     <span>{{"PATIENT_QUEUE_TRANSLATION_KEY"| translate}}</span>
                 </a>

--- a/ui/app/clinical/constants.js
+++ b/ui/app/clinical/constants.js
@@ -70,7 +70,7 @@ Bahmni.Clinical.Constants = (function () {
         otherActiveDrugOrders: "Other Active DrugOrders",
         dispensePrivilege: "bahmni:clinical:dispense",
         mandatoryVisitConfigUrl: "config/visitMandatoryTab.json",
-        defaultExtensionName: "default",
+        defaultExtensionName: "v2",
         bacteriologyConstants: bacteriologyConstants,
         globalPropertyToFetchActivePatients: 'emrapi.sqlSearch.activePatients',
         adtPrivilege: "app:adt",

--- a/ui/app/clinical/patientcontrolpanel/views/controlPanel.html
+++ b/ui/app/clinical/patientcontrolpanel/views/controlPanel.html
@@ -37,7 +37,7 @@
 
         <h2>{{'CONTROL_PANEL_OTHER_ACTIONS'|translate}}</h2>
         <ul class="bahmni-home">
-            <li><a class="header-logo" href="../home/index.html"><i class="fa fa-home"></i>{{"BAHMNI_HOME_TRANSLATION_KEY"| translate}}</a></li>
+            <li><a class="header-logo" href="/bahmni/home/index.html"><i class="fa fa-home"></i>{{"BAHMNI_HOME_TRANSLATION_KEY"| translate}}</a></li>
         </ul>
         <ul>
             <li>

--- a/ui/app/common/auth/authentication.js
+++ b/ui/app/common/auth/authentication.js
@@ -23,7 +23,7 @@ angular.module('authentication')
     }]).run(['$rootScope', '$window', '$timeout', function ($rootScope, $window, $timeout) {
         $rootScope.$on('event:auth-loginRequired', function () {
             $timeout(function () {
-                $window.location = "../home/index.html#/login";
+                $window.location = "/bahmni/home/index.html#/login";
             });
         });
     }]).service('sessionService', ['$rootScope', '$http', '$q', '$bahmniCookieStore', 'userService', '$window', function ($rootScope, $http, $q, $bahmniCookieStore, userService, $window) {
@@ -231,7 +231,7 @@ angular.module('authentication')
         function logoutUser () {
             auditLogService.log(undefined, 'USER_LOGOUT_SUCCESS', undefined, 'MODULE_LABEL_LOGOUT_KEY').then(function () {
                 sessionService.destroy().then(function () {
-                    $window.location = "../home/index.html#/login";
+                    $window.location = "/bahmni/home/index.html#/login";
                 });
             });
         }

--- a/ui/app/common/displaycontrols/navigationlinks/directives/navigationLinks.js
+++ b/ui/app/common/displaycontrols/navigationlinks/directives/navigationLinks.js
@@ -13,7 +13,7 @@ angular.module('bahmni.common.displaycontrol.navigationlinks')
                 {
                     "name": "home",
                     "translationKey": "HOME_DASHBOARD_KEY",
-                    "url": "../home/#/dashboard",
+                    "url": "/bahmni/home/#/dashboard",
                     "title": "Home"
                 },
                 {

--- a/ui/app/common/ui-helper/controllers/messageController.js
+++ b/ui/app/common/ui-helper/controllers/messageController.js
@@ -35,7 +35,7 @@ angular.module("bahmni.common.uiHelper").controller("MessageController", [ "$sco
         $scope.discardChanges = function (level) {
             $state.discardChanges = true;
             $scope.hideMessage(level);
-            return $state.isPatientSearch ? $location.path('/default/patient/search') : $location.path('/default/patient/' + $state.newPatientUuid + "/dashboard");
+            return $state.isPatientSearch ? $location.path('/v2/patient/search') : $location.path('/default/patient/' + $state.newPatientUuid + "/dashboard");
         };
     }
 ]);

--- a/ui/app/document-upload/app.js
+++ b/ui/app/document-upload/app.js
@@ -7,7 +7,7 @@ angular.module('documentupload').config(['$stateProvider', '$httpProvider', '$ur
     function ($stateProvider, $httpProvider, $urlRouterProvider, $bahmniTranslateProvider, $compileProvider) {
         $urlRouterProvider.otherwise('/search');
         var patientSearchBackLink = {label: "", state: "search", accessKey: "p", id: "patients-link", icon: "fa-users"};
-        var homeBackLink = {label: "", url: "../home/", accessKey: "h", icon: "fa-home"};
+        var homeBackLink = {label: "", url: "/bahmni/home/", accessKey: "h", icon: "fa-home"};
 
         // @if DEBUG='production'
         $compileProvider.debugInfoEnabled(false);

--- a/ui/app/home/controllers/changePasswordController.js
+++ b/ui/app/home/controllers/changePasswordController.js
@@ -5,7 +5,7 @@ angular.module('bahmni.home')
         $scope.passwordDoesNotMatch = false;
         $scope.passwordPolicies = [];
         $scope.redirectToHomePage = function () {
-            $state.go('dashboard');
+            $window.location = '/bahmni/home/';
         };
         var checkPasswordMatches = function () {
             return $scope.loginInfo.newPassword == $scope.loginInfo.confirmPassword;
@@ -65,7 +65,7 @@ angular.module('bahmni.home')
                 sessionService.loadCredentials().then(function (data) {
                 });
             }, function () {
-                $window.location = "../home/index.html#/login";
+                $window.location = "/bahmni/home/index.html#/login";
             });
         };
         init();

--- a/ui/app/home/controllers/loginController.js
+++ b/ui/app/home/controllers/loginController.js
@@ -4,7 +4,7 @@ angular.module('bahmni.home')
     .controller('LoginController', ['$rootScope', '$scope', '$window', '$location', 'sessionService', 'initialData', 'spinner', '$q', '$stateParams', '$bahmniCookieStore', 'localeService', '$translate', 'userService', 'auditLogService', '$state',
         function ($rootScope, $scope, $window, $location, sessionService, initialData, spinner, $q, $stateParams, $bahmniCookieStore, localeService, $translate, userService, auditLogService, $state) {
             var redirectUrl = $location.search()['from'];
-            var landingPagePath = "/dashboard";
+            var landingPagePath = "/bahmni/home";
             var loginPagePath = "/login";
             $scope.locations = initialData.locations;
             $scope.loginInfo = {};
@@ -106,7 +106,7 @@ angular.module('bahmni.home')
             var redirectToLandingPageIfAlreadyAuthenticated = function () {
                 sessionService.get().then(function (data) {
                     if (data.authenticated) {
-                        $location.path(landingPagePath);
+                        $window.location.href = landingPagePath;
                     }
                 });
             };
@@ -236,7 +236,7 @@ angular.module('bahmni.home')
                                 if (res) {
                                     $window.location.replace(redirectUrl);
                                 } else {
-                                    $location.url(landingPagePath);
+                                    $window.location.href = landingPagePath;
                                 }
                             });
                         } else {

--- a/ui/app/home/controllers/loginLocationController.js
+++ b/ui/app/home/controllers/loginLocationController.js
@@ -4,7 +4,7 @@ angular.module('bahmni.home')
     .controller('LoginLocationController', ['$rootScope', '$scope', '$window', '$location', 'sessionService', 'initialData', 'spinner', '$q', '$stateParams', '$bahmniCookieStore', 'localeService', '$translate', 'userService', 'auditLogService',
         function ($rootScope, $scope, $window, $location, sessionService, initialData, spinner, $q, $stateParams, $bahmniCookieStore, localeService, $translate, userService, auditLogService) {
             var redirectUrl = $location.search()['from'];
-            var landingPagePath = "/dashboard";
+            var landingPagePath = "/bahmni/home";
             var loginPagePath = "/login";
             const LOGIN_LOCATIONS = "Login Locations";
             $scope.loginInfo = {};
@@ -103,7 +103,7 @@ angular.module('bahmni.home')
             var redirectToLandingPageIfAlreadyAuthenticated = function () {
                 sessionService.get().then(function (data) {
                     if (data.authenticated) {
-                        $location.path(landingPagePath);
+                        $window.location.href = landingPagePath;
                     }
                 });
             };
@@ -138,7 +138,7 @@ angular.module('bahmni.home')
                 spinner.forPromise(deferrable.promise).then(
                     function (data) {
                         if (data) return;
-                        $location.url(landingPagePath);
+                        $window.location.href = landingPagePath;
                     }
                 );
             };

--- a/ui/app/home/views/changePassword.html
+++ b/ui/app/home/views/changePassword.html
@@ -17,7 +17,7 @@
                     <div class="opd-header-top">
                         <header class="reg-header">
                             <ul class="top-nav fl">
-                                <li><a class="back-btn" accesskey="h" href="../home/index.html"><i class="fa fa-home"></i></a></li>
+                                <li><a class="back-btn" accesskey="h" href="/bahmni/home/index.html"><i class="fa fa-home"></i></a></li>
                             </ul>
                         </header>
                     </div>

--- a/ui/app/home/views/errorLog.html
+++ b/ui/app/home/views/errorLog.html
@@ -2,7 +2,7 @@
     <div class="opd-header-top">
         <header class="reg-header">
             <ul class="top-nav fl">
-                <li><a class="back-btn" accesskey="h" href="../home/index.html"><i class="fa fa-home"></i></a></li>
+                <li><a class="back-btn" accesskey="h" href="/bahmni/home/index.html"><i class="fa fa-home"></i></a></li>
             </ul>
         </header>
     </div>

--- a/ui/app/orders/app.js
+++ b/ui/app/orders/app.js
@@ -9,7 +9,7 @@ angular
         function ($urlRouterProvider, $stateProvider, $httpProvider, $bahmniTranslateProvider, $compileProvider) {
             $httpProvider.defaults.headers.common['Disable-WWW-Authenticate'] = true;
             $urlRouterProvider.otherwise('/search');
-            var homeBacklink = {label: "Home", url: "../home/", accessKey: "h", icon: "fa-home"};
+            var homeBacklink = {label: "Home", url: "/bahmni/home/", accessKey: "h", icon: "fa-home"};
             var searchBacklink = {label: "Search", state: "search", accessKey: "p", icon: "fa-users"};
 
         // @if DEBUG='production'
@@ -76,6 +76,6 @@ angular
 
 ).run(['backlinkService', '$window', function (backlinkService, $window) {
     moment.locale($window.localStorage["NG_TRANSLATE_LANG_KEY"] || "en");
-    backlinkService.addUrl({label: "Patient Search", url: "../home/"});
+    backlinkService.addUrl({label: "Patient Search", url: "/bahmni/home/"});
 }]);
 

--- a/ui/app/orders/views/header.html
+++ b/ui/app/orders/views/header.html
@@ -1,5 +1,5 @@
 <div class="back-btn-link">
-    <a ng-href="../clinical/#/default/patient/{{patient.uuid}}/dashboard" title="Back to {{patient.name}}'s Clinical Dashboard">
+    <a ng-href="../../clinical/{{patient.uuid}}" title="Back to {{patient.name}}'s Clinical Dashboard">
         <img class="patient-image" ng-src="{{::patient.image}}" fallback-src="../images/blank-user.gif">
         <span class="patient-info">
             <span class="patient-name" >{{patient.name}} </span>

--- a/ui/app/ot/app.js
+++ b/ui/app/ot/app.js
@@ -9,7 +9,7 @@ angular.module('ot').config(['$stateProvider', '$httpProvider', '$urlRouterProvi
     function ($stateProvider, $httpProvider, $urlRouterProvider, $bahmniTranslateProvider, $compileProvider) {
         $urlRouterProvider.otherwise('/home');
 
-        var homeBackLink = {type: "link", name: "Home", value: "../home/", accessKey: "h", icon: "fa-home"};
+        var homeBackLink = {type: "link", name: "Home", value: "/bahmni/home/", accessKey: "h", icon: "fa-home"};
         var otSchedulingLink = {type: "state", name: "OT_SCHEDULING_KEY", value: "otScheduling", accessKey: "b"};
         var queuesLink = {type: "state", name: "OT_SURGICAL_QUEUES_KEY", value: "home", accessKey: "b"};
         var navigationLinks = [queuesLink, otSchedulingLink];

--- a/ui/app/registration/constants.js
+++ b/ui/app/registration/constants.js
@@ -14,15 +14,15 @@ Bahmni.Registration.Constants = {
     webServiceRestBaseURL: hostUrl + "/openmrs/ws/rest/v1",
     basePatientUrl: RESTWS_V1 + "/patient/",
     patientSearchURL: "/search",
-    existingPatient: "/bahmni/registration/index.html#/patient/",
-    newPatient: "/bahmni/registration/index.html#/patient/new",
+    existingPatient: "/bahmni/v1/registration/index.html#/patient/",
+    newPatient: "/bahmni/v1/registration/index.html#/patient/new",
     allAddressFileds: ["uuid", "preferred", "address1", "address2", "address3", "address4", "address5", "address6", "cityVillage", "countyDistrict", "stateProvince", "postalCode", "country", "latitude", "longitude"],
     nextStepConfigId: "org.bahmni.registration.patient.next",
     patientNameDisplayOrder: ["firstName", "middleName", "lastName"],
     registrationMessage: "REGISTRATION_MESSAGE",
     enableWhatsAppButton: false,
     enableDashboardRedirect: false,
-    dashboardUrl: "/bahmni/clinical/index.html#/default/patient/{{patientUuid}}/dashboard",
+    dashboardUrl: "/bahmni/v1/clinical/index.html#/default/patient/{{patientUuid}}/dashboard",
     certificateHeader: "Print Header"
 };
 

--- a/ui/app/registration/controllers/navigationController.js
+++ b/ui/app/registration/controllers/navigationController.js
@@ -18,7 +18,7 @@ angular.module('bahmni.registration')
                 $rootScope.errorMessage = null;
                 sessionService.destroy().then(
                     function () {
-                        $window.location = "../home/";
+                        $window.location = "/bahmni/home/";
                     }
                 );
             };

--- a/ui/app/registration/views/header.html
+++ b/ui/app/registration/views/header.html
@@ -1,6 +1,6 @@
 <header class="reg-header" ng-controller="NavigationController">
         <ul class="top-nav" ng-class="{'has-print' : hasPrint}">
-            <a class="back-btn" accesskey="h" href="../home/index.html" ng-click="onHomeNavigate($event)"><i class="fa fa-home"></i></a>
+            <a class="back-btn" accesskey="h" href="/bahmni/home/index.html" ng-click="onHomeNavigate($event)"><i class="fa fa-home"></i></a>
             <li ng-repeat="extension in ::extensions">
                 <a ng-click="goTo(extension.url)" accesskey="{{::extension.shortcutKey | translate}}"><i class="{{::extension.icon}} fa fa-white small"></i>
                     <span class="nav-link" ng-bind-html="::extension | titleTranslate"></span></a>

--- a/ui/app/reports/controllers/dashboardHeaderController.js
+++ b/ui/app/reports/controllers/dashboardHeaderController.js
@@ -4,7 +4,7 @@ angular.module('bahmni.reports')
     .controller('DashboardHeaderController', ['$scope', 'appService', '$state',
         function ($scope, appService, $state) {
             var setBackLinks = function () {
-                var backLinks = [{label: "Home", url: "../home/", accessKey: "h", icon: "fa-home"}];
+                var backLinks = [{label: "Home", url: "/bahmni/home/", accessKey: "h", icon: "fa-home"}];
                 if (appService.getAppDescriptor().getConfigValue("enableReportQueue")) {
                     backLinks.push({text: "REPORTS_HEADER_REPORTS", state: "dashboard.reports", accessKey: "d"});
                     backLinks.push({text: "REPORTS_HEADER_MY_REPORTS", state: "dashboard.myReports", accessKey: "m"});


### PR DESCRIPTION
# BAH-4733 Summary

Migrated the React frontend from `/bahmni-new/` to `/bahmni/`, while moving legacy Angular modules under `/bahmni/v1/`.


## New Privilege Model

Added privilege-based access for legacy Angular UX:

* `app:legacy-registration`

  * Shows “Registration (Legacy)” tile
* `app:clinical:legacyPatientTabs`

  * Shows “Active (Legacy)” and “All (Legacy)” tabs

Users without these privileges see only the new React experience.

## Major Technical Updates

* Updated proxy routing to serve React and Angular apps separately
* Converted many relative Angular URLs to absolute `/bahmni/...` paths
* Added `/bahmni/v1/...` routing for legacy modules
* React assets moved under `/bahmni/static/`
* Added session/auth guard (`SessionGate`) for React apps
* Added redirects from old Angular clinical URLs to new React URLs
* Updated login/change-password paths to legacy Angular home
* Added proxy caching support

## Repository Updates

Changes were made across 7 repositories:

1. Bahmni `bahmni-proxy`
2. `bahmni-apps-frontend`
3. `openmrs-module-bahmniapps`
4. `standard-config`
5. `openmrs-module-appointments-frontend`
6. `clinic-config`
7. `bahmni-docker`

## Outcome

* React becomes the primary frontend under `/bahmni/`
* Angular legacy modules remain accessible under `/bahmni/v1/`
* Smooth coexistence between new React UX and legacy Angular UX
* Legacy access is controlled using privileges
