### PR TITLE
BAH-4777 fix locale dropdown bug.

### DIFF
--- a/ui/app/common/domain/services/localeService.js
+++ b/ui/app/common/domain/services/localeService.js
@@ -18,8 +18,11 @@ angular.module('bahmni.common.domain')
                     property: 'locale.allowed.list'
                 },
                 withCredentials: true,
+                cache: false,
                 headers: {
-                    Accept: 'text/plain'
+                    Accept: 'text/plain',
+                    'Cache-Control': 'no-cache',
+                    'Pragma': 'no-cache'
                 }
             });
         };
@@ -58,8 +61,11 @@ angular.module('bahmni.common.domain')
         this.getLocalesLangs = function () {
             return $http.get(Bahmni.Common.Constants.localeLangs, {
                 method: "GET",
+                cache: false,
                 headers: {
-                    Accept: 'text/plain'
+                    Accept: 'text/plain',
+                    'Cache-Control': 'no-cache',
+                    'Pragma': 'no-cache'
                 }
             });
         };

--- a/ui/app/home/controllers/loginController.js
+++ b/ui/app/home/controllers/loginController.js
@@ -62,20 +62,25 @@ angular.module('bahmni.home')
                 $rootScope.cookieExpirationTime = response.data.loggedInUrlCookieExpirationTimeInMinutes;
             });
 
-            $q.all([localeService.getLocalesLangs(), promise]).then(function (responses) {
-                localeLanguages = (responses[0].data && responses[0].data.locales) || [];
-                var raw = responses[1].data;
-                var localeList = (angular.isString(raw) ? raw : '')
-                    .replace(/\s+/g, '').split(',').filter(Boolean);
-                $scope.locales = _.map(localeList, function (locale) {
-                    return findLanguageByLocale(locale) || {"code": locale, "nativeName": locale};
-                });
+            var setLocalesFromAllowedList = function () {
+                promise.then(function (response) {
+                    var raw = response.data;
+                    var localeList = (angular.isString(raw) ? raw : '')
+                        .replace(/\s+/g, '').split(',').filter(Boolean);
+                    $scope.locales = _.map(localeList, function (locale) {
+                        return findLanguageByLocale(locale) || {"code": locale, "nativeName": locale};
+                    });
 
-                if (_.isEmpty($scope.locales)) {
-                    $scope.locales = [{"code": "en", "nativeName": "English"}];
-                }
-                $scope.selectedLocale = $translate.use() ? $translate.use() : $scope.locales[0].code;
-            });
+                    if (_.isEmpty($scope.locales)) {
+                        $scope.locales = [{"code": "en", "nativeName": "English"}];
+                    }
+                    $scope.selectedLocale = $translate.use() ? $translate.use() : $scope.locales[0].code;
+                });
+            };
+
+            localeService.getLocalesLangs().then(function (response) {
+                localeLanguages = (response.data && response.data.locales) || [];
+            }).finally(setLocalesFromAllowedList);
 
             localeService.defaultLocale().then(function (response) {
                 localStorage.setItem("openmrsDefaultLocale", response.data || "en");

--- a/ui/app/home/controllers/loginController.js
+++ b/ui/app/home/controllers/loginController.js
@@ -72,7 +72,8 @@ angular.module('bahmni.home')
                     });
 
                     if (_.isEmpty($scope.locales)) {
-                        $scope.locales = [{"code": "en", "nativeName": "English"}];
+                        var savedLoacale = $translate.use() || "en";
+                        $scope.locales = [findLanguageByLocale(savedLoacale) || {"code": savedLoacale, "nativeName": savedLoacale}];
                     }
                     $scope.selectedLocale = $translate.use() ? $translate.use() : $scope.locales[0].code;
                 });

--- a/ui/app/home/controllers/loginController.js
+++ b/ui/app/home/controllers/loginController.js
@@ -62,22 +62,19 @@ angular.module('bahmni.home')
                 $rootScope.cookieExpirationTime = response.data.loggedInUrlCookieExpirationTimeInMinutes;
             });
 
-            localeService.getLocalesLangs().then(function (response) {
-                localeLanguages = response.data.locales;
-            }).finally(function () {
-                promise.then(function (response) {
-                    var localeList = response.data.replace(/\s+/g, '').split(',');
-                    $scope.locales = [];
-                    _.forEach(localeList, function (locale) {
-                        var localeLanguage = findLanguageByLocale(locale);
-                        if (_.isUndefined(localeLanguage)) {
-                            $scope.locales.push({"code": locale, "nativeName": locale});
-                        } else {
-                            $scope.locales.push(localeLanguage);
-                        }
-                    });
-                    $scope.selectedLocale = $translate.use() ? $translate.use() : $scope.locales[0].code;
+            $q.all([localeService.getLocalesLangs(), promise]).then(function (responses) {
+                localeLanguages = (responses[0].data && responses[0].data.locales) || [];
+                var raw = responses[1].data;
+                var localeList = (angular.isString(raw) ? raw : '')
+                    .replace(/\s+/g, '').split(',').filter(Boolean);
+                $scope.locales = _.map(localeList, function (locale) {
+                    return findLanguageByLocale(locale) || {"code": locale, "nativeName": locale};
                 });
+
+                if (_.isEmpty($scope.locales)) {
+                    $scope.locales = [{"code": "en", "nativeName": "English"}];
+                }
+                $scope.selectedLocale = $translate.use() ? $translate.use() : $scope.locales[0].code;
             });
 
             localeService.defaultLocale().then(function (response) {

--- a/ui/test/unit/common/domain/services/localeService.spec.js
+++ b/ui/test/unit/common/domain/services/localeService.spec.js
@@ -73,4 +73,26 @@ describe('localeService', function () {
             done();
         });
     });
+
+    it('should disable caching while fetching the allowed list of locales', function () {
+        _$http.get.and.returnValue(specUtil.respondWith({"data": localesList}));
+
+        localeService.allowedLocalesList();
+
+        var requestConfig = _$http.get.calls.mostRecent().args[1];
+        expect(requestConfig.cache).toBe(false);
+        expect(requestConfig.headers['Cache-Control']).toEqual('no-cache');
+        expect(requestConfig.headers.Pragma).toEqual('no-cache');
+    });
+
+    it('should disable caching while fetching locale languages', function () {
+        _$http.get.and.returnValue(specUtil.respondWith({"data": localeLangs}));
+
+        localeService.getLocalesLangs();
+
+        var requestConfig = _$http.get.calls.mostRecent().args[1];
+        expect(requestConfig.cache).toBe(false);
+        expect(requestConfig.headers['Cache-Control']).toEqual('no-cache');
+        expect(requestConfig.headers.Pragma).toEqual('no-cache');
+    });
 });

--- a/ui/test/unit/home/controllers/loginController.spec.js
+++ b/ui/test/unit/home/controllers/loginController.spec.js
@@ -159,6 +159,25 @@ describe('loginController', function () {
         expect(scopeMock.locales).toEqual([{code: 'it', nativeName: 'it'}]);
     });
 
+    it('should still populate locales from the allowed list when getLocalesLangs fails', function () {
+        // getLocalesLangs() rejects: its .then(success) is skipped but .finally() still runs,
+        // so the dropdown is built from the allowed list using the locale codes as names.
+        var failedLangsPromise = {
+            then: function () { return this; },
+            finally: function (callback) { callback(); return this; }
+        };
+        localeService.getLocalesLangs.and.returnValue(failedLangsPromise);
+        localeService.allowedLocalesList.and.returnValue(specUtil.simplePromise({data: "en"}));
+        loginController();
+        expect(scopeMock.locales).toEqual([{code: 'en', nativeName: 'en'}]);
+    });
+
+    it('should default to English when the allowed locales list is empty', function () {
+        localeService.allowedLocalesList.and.returnValue(specUtil.simplePromise({data: ""}));
+        loginController();
+        expect(scopeMock.locales).toEqual([{code: 'en', nativeName: 'English'}]);
+    });
+
     it ("should fetch bahmniCore data and assign it to windows object ",function() {
             loginController();
             var fakeHttpGetPromise = {


### PR DESCRIPTION
**Bug**: Locale dropdown on the login page does not populate without clearing browser cache.

**Root Cause**:

The login page fetches the allowed locale list from `/openmrs/ws/rest/v1/bahmnicore/sql/globalproperty?property=locale.allowed.list`. During server warmup — before OpenMRS has fully initialized or the database connection pool is ready — this endpoint returns null, which Spring serializes as an empty 200 OK response. Since there were no cache-control headers on the request, the browser cached this empty response. Every subsequent login page load served the cached empty body. The frontend had no guard against empty data: `"".split(',')` produces `[""]` (one blank entry), rendering the dropdown blank. Clearing the browser cache forced a fresh request — by which time the server was ready and returned the correct locale list, which is why the bug appeared to "fix itself" after a cache clear.

**Fix**:

- Added `cache: false` + `Cache-Control: no-cache` / `Pragma: no-cache` headers to both `allowedLocalesList()` and `getLocalesLangs()` in `localeService.js` to prevent the browser from caching empty warmup responses. The shared headers config is extracted into a `noCacheHeaders` constant to avoid duplication.
- Added defensive parsing in `loginController.js`: null-safe locale list access, `.filter(Boolean)` to strip empty CSV entries, and a fallback to the user's previously selected locale (via `$translate.use()`) or English when the allowed list is empty.
- A `getLocalesLangs()` failure no longer blocks dropdown rendering — the `.finally()` chain ensures the dropdown always builds from the allowed list.

**Tests**:

- `localeService.spec.js`: asserts `cache: false` + no-cache headers on both HTTP requests, using a shared `expectNoCacheHeaders()` helper to avoid repetition.
- `loginController.spec.js`: locale-mapping cases (known locale, unknown locale, empty list fallback) are covered via a data-driven `forEach`. Separate test verifies that a `getLocalesLangs()` failure still allows the dropdown to populate from the allowed list.