### PR TITLE
BAH-4430: Add feature toggle for no known allergy capturing

### DIFF
--- a/micro-frontends/src/next-ui/Components/AddAllergy/AddAllergy.jsx
+++ b/micro-frontends/src/next-ui/Components/AddAllergy/AddAllergy.jsx
@@ -29,7 +29,7 @@ import { SelectReactions } from "../SelectReactions/SelectReactions";
 
 
   export function AddAllergy(props) {
-    const { patient, onClose, allergens, reaction, severityOptions, onSave, existingAllergies, noKnownAllergyUuid } = props;
+    const { patient, onClose, allergens, reaction, severityOptions, onSave, existingAllergies, noKnownAllergyUuid, enableNoKnownAllergy } = props;
     const [allergen, setAllergen] = React.useState({});
     const [reactions, setReactions] = React.useState([]);
     const [severity, setSeverity] = React.useState("");
@@ -110,7 +110,7 @@ import { SelectReactions } from "../SelectReactions/SelectReactions";
     };
 
 
-    const showKnownAllergySelector = existingAllergies?.length === 0 && !!noKnownAllergyUuid
+    const showKnownAllergySelector = existingAllergies?.length === 0 && !!noKnownAllergyUuid && enableNoKnownAllergy
 
     return (
         <div className={"next-ui"}>
@@ -225,5 +225,6 @@ import { SelectReactions } from "../SelectReactions/SelectReactions";
     patient: propTypes.object.isRequired,
     severityOptions: propTypes.array.isRequired,
     existingAllergies: propTypes.array.isRequired,
-    noKnownAllergyUuid: propTypes.string.isRequired
+    noKnownAllergyUuid: propTypes.string.isRequired,
+    enableNoKnownAllergy: propTypes.bool.isRequired
   };

--- a/micro-frontends/src/next-ui/Components/AddAllergy/AddAllergy.jsx
+++ b/micro-frontends/src/next-ui/Components/AddAllergy/AddAllergy.jsx
@@ -110,7 +110,7 @@ import { SelectReactions } from "../SelectReactions/SelectReactions";
     };
 
 
-    const showKnownAllergySelector = existingAllergies?.length === 0
+    const showKnownAllergySelector = existingAllergies?.length === 0 && !!noKnownAllergyUuid
 
     return (
         <div className={"next-ui"}>

--- a/micro-frontends/src/next-ui/Components/AddAllergy/AddAllergy.spec.jsx
+++ b/micro-frontends/src/next-ui/Components/AddAllergy/AddAllergy.spec.jsx
@@ -383,7 +383,7 @@ describe("AddAllergy", () => {
     }, "patient#1");
   });
 
-  it("should show known allergy selector when existingAllergies is empty", () => {
+  it("should show known allergy selector when existingAllergies is empty and enableNoKnownAllergy is true", () => {
     render(
         <IntlProvider locale="en">
           <AddAllergy
@@ -396,6 +396,7 @@ describe("AddAllergy", () => {
               reaction={mockReactionsData}
               existingAllergies={[]}
               noKnownAllergyUuid={"000000AAAAAA"}
+              enableNoKnownAllergy={true}
           />
         </IntlProvider>
     );
@@ -415,6 +416,27 @@ describe("AddAllergy", () => {
               reaction={mockReactionsData}
               existingAllergies={mockExistingAllergies}
               noKnownAllergyUuid={"000000AAAAAA"}
+              enableNoKnownAllergy={true}
+          />
+        </IntlProvider>
+    );
+    expect(() => screen.getByText("Does the patient have any known allergies?")).toThrow();
+  });
+
+  it("should not show known allergy selector when enableNoKnownAllergy is false even with noKnownAllergyUuid set", () => {
+    render(
+        <IntlProvider locale="en">
+          <AddAllergy
+              onClose={onClose}
+              onSave={onSave}
+              patient={patient}
+              provider={provider}
+              severityOptions={mockSeverityData}
+              allergens={mockAllergensData}
+              reaction={mockReactionsData}
+              existingAllergies={[]}
+              noKnownAllergyUuid={"000000AAAAAA"}
+              enableNoKnownAllergy={false}
           />
         </IntlProvider>
     );
@@ -462,6 +484,7 @@ describe("AddAllergy", () => {
               reaction={mockReactionsData}
               existingAllergies={[]}
               noKnownAllergyUuid="000000AAAAAA"
+              enableNoKnownAllergy={true}
           />
         </IntlProvider>
     );
@@ -484,6 +507,7 @@ describe("AddAllergy", () => {
               reaction={mockReactionsData}
               existingAllergies={[]}
               noKnownAllergyUuid={"000000AAAAAA"}
+              enableNoKnownAllergy={true}
           />
         </IntlProvider>
     );

--- a/micro-frontends/src/next-ui/Containers/patientAlergies/PatientAlergiesControl.jsx
+++ b/micro-frontends/src/next-ui/Containers/patientAlergies/PatientAlergiesControl.jsx
@@ -56,6 +56,7 @@ export function PatientAlergiesControl(props) {
   const { patient, provider, activeVisit, allergyControlConceptIdMap } = hostData;
 
   const isAddButtonEnabled = activeVisit && activeVisit.uuid;
+  const enableNoKnownAllergy = appService.getAppDescriptor().getConfigValue("enableNoKnownAllergy") || false;
 
   const extractAllergenData = (allergenData, allergenKind) =>
     allergenData?.setMembers
@@ -223,6 +224,7 @@ export function PatientAlergiesControl(props) {
   }, []);
 
   useEffect(() => {
+    if (!enableNoKnownAllergy) return;
     getNoKnownAllergyUuid().then((code) => {
       setNoKnownAllergyUuid(code);
     });

--- a/micro-frontends/src/next-ui/Containers/patientAlergies/PatientAlergiesControl.jsx
+++ b/micro-frontends/src/next-ui/Containers/patientAlergies/PatientAlergiesControl.jsx
@@ -224,7 +224,6 @@ export function PatientAlergiesControl(props) {
   }, []);
 
   useEffect(() => {
-    if (!enableNoKnownAllergy) return;
     getNoKnownAllergyUuid().then((code) => {
       setNoKnownAllergyUuid(code);
     });
@@ -276,6 +275,7 @@ export function PatientAlergiesControl(props) {
                 }
               }}
               noKnownAllergyUuid={noKnownAllergyUuid}
+              enableNoKnownAllergy={enableNoKnownAllergy}
             />
           )}
           <NotificationCarbon messageDuration={3000} onClose={()=>{setShowSuccessPopup(false); window.location.reload()}} showMessage={showSuccessPopup} kind={"success"} title={<FormattedMessage id={"ALLERGY_SAVED_SUCCESS"} defaultMessage="Allergy information saved successfully"/>} hideCloseButton={true}/>

--- a/micro-frontends/src/next-ui/Containers/patientAlergies/PatientAlergiesControl.spec.jsx
+++ b/micro-frontends/src/next-ui/Containers/patientAlergies/PatientAlergiesControl.spec.jsx
@@ -11,6 +11,7 @@ import React from "react";
 import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { PatientAlergiesControl } from "./PatientAlergiesControl";
 import { IntlProvider } from "react-intl";
+import { getNoKnownAllergyUuid } from "../../utils/PatientAllergiesControl/AllergyControlUtils";
 
 const mockMedicationResponseData = {
   uuid: "100340AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -231,5 +232,21 @@ describe("PatientAlergiesControl", () => {
 
     fireEvent.click(getByTestId("cancel"));
     expect(container.querySelector(".overlay-next-ui")).toBeNull();
+  });
+
+  it("should fetch noKnownAllergyUuid even when enableNoKnownAllergy toggle is off", async () => {
+    const mockAppServiceToggleOff = {
+      getAppDescriptor: () => ({
+        getConfigValue: () => false
+      })
+    };
+    render(
+      <IntlProvider locale="en">
+        <PatientAlergiesControl hostData={testHostData} appService={mockAppServiceToggleOff}/>
+      </IntlProvider>
+    );
+    await waitFor(() => {
+      expect(getNoKnownAllergyUuid).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `enableNoKnownAllergy` config flag (default `false`) read from `clinical app.json` via `appService`
- When enabled, shows the \"Does the patient have any known allergies?\" selector in `AddAllergy`
- `noKnownAllergyUuid` is always fetched regardless of the toggle, so \"No Known Allergy\" is always filtered out of allergen search results
- No behavioral change for existing deployments unless the flag is explicitly enabled

## Behaviour

| Scenario | Toggle OFF (default) | Toggle ON |
|---|---|---|
| \"No Known Allergy\" in allergen search | Hidden | Hidden |
| \"Does the patient have any known allergies?\" selector | Hidden | Shown |

## Configuration

Add to `clinical app.json`:
\`\`\`json
"enableNoKnownAllergy": true
\`\`\`

## Files Changed

- `micro-frontends/src/next-ui/Components/AddAllergy/AddAllergy.jsx`
- `micro-frontends/src/next-ui/Containers/patientAlergies/PatientAlergiesControl.jsx`
- `micro-frontends/src/next-ui/Components/AddAllergy/AddAllergy.spec.jsx`
- `micro-frontends/src/next-ui/Containers/patientAlergies/PatientAlergiesControl.spec.jsx`

## Test plan

- [ ] Verify \"No Known Allergy\" does not appear in allergen search when toggle is OFF
- [ ] Verify \"No Known Allergy\" does not appear in allergen search when toggle is ON
- [ ] Verify allergy capture UI (\"Does the patient have any known allergies?\") is hidden when `enableNoKnownAllergy: false` (default)
- [ ] Verify allergy capture UI appears when `enableNoKnownAllergy: true` in `clinical app.json`
- [ ] Verify no regression in existing allergy display/save flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)