### PR TITLE
BAH-3425: Added visual deceased indicator to patient profiles across …

### DIFF
--- a/ui/app/clinical/common/views/visitHeader.html
+++ b/ui/app/clinical/common/views/visitHeader.html
@@ -5,7 +5,7 @@
         <a class="back-btn dashboard-link" id="dashboard-link" ng-click="gotoPatientDashboard()" title="Back to patient dashboard">
             <img class="patient-image" ng-src="{{::patient.image}}" fallback-src="../images/blank-user.gif">
             <span class="patient-info">
-                <span class="patient-name" >{{patient.name}} </span>
+                <span class="patient-name" >{{patient.name}} </span><span ng-if="patient.isDead || patientContext.isDead" style="color:red; font-weight:bold; margin-left: 5px;">(Deceased)</span>
                 <span class="patient-id">{{patient.identifier}}</span>
             </span>
         </a>

--- a/ui/app/clinical/dashboard/views/clinicalDashboardHeader.html
+++ b/ui/app/clinical/dashboard/views/clinicalDashboardHeader.html
@@ -13,7 +13,7 @@
                 <a class="back-btn-link" id="dashboard-link" accesskey="d" ng-click="gotoPatientDashboard()" title="Back to {{patient.name}} Dashboard">
                     <img class="patient-image" ng-src="{{::patient.image}}" fallback-src="../images/blank-user.gif">
                 <span class="patient-info">
-                    <span class="patient-name" >{{patient.name}} </span>
+                    <span class="patient-name" >{{patient.name}} </span><span ng-if="patient.isDead || patientContext.isDead" style="color:red; font-weight:bold; margin-left: 5px;">(Deceased)</span>
                     <span class="patient-id">{{patient.identifier}}</span>
                 </span>
                 </a>

--- a/ui/app/clinical/dashboard/views/recentPatients.html
+++ b/ui/app/clinical/dashboard/views/recentPatients.html
@@ -16,10 +16,10 @@
         <div class="recent-patients-wrapper" ng-show="triggeredByButton || showPatientsBySearch">
             <span  class="recent_patient" ng-if="!search.searchParameter">{{'RECENT_PATIENTS_LABEL'|translate}}</span>
             <div ng-repeat="recent in recentlyViewedPatients track by $index" ng-class ="{'currentPatient': recent.uuid == patient.uuid}" ng-if="!search.searchParameter">
-                <a ng-href="#/{{configName}}/patient/{{recent.uuid}}/dashboard" ng-click="closeAllDialogs()"> <span>{{recent.name}}</span> ({{recent.identifier}})</a>
+                <a ng-href="#/{{configName}}/patient/{{recent.uuid}}/dashboard" ng-click="closeAllDialogs()"> <span>{{recent.name}}</span><span ng-if="recent.isDead" style="color:red; font-weight:bold; margin-left: 5px;">(Deceased)</span> ({{recent.identifier}})</a>
             </div>
             <div ng-repeat="patient in search.searchResults track by $index" ng-if="search.searchParameter">
-                <a ng-href="#/{{configName}}/patient/{{patient.uuid}}/dashboard" ng-click="closeAllDialogs()"> <span>{{patient.name}}</span> ({{patient.identifier}})</a>
+                <a ng-href="#/{{configName}}/patient/{{patient.uuid}}/dashboard" ng-click="closeAllDialogs()"> <span>{{patient.name}}</span><span ng-if="patient.isDead" style="color:red; font-weight:bold; margin-left: 5px;">(Deceased)</span> ({{patient.identifier}})</a>
             </div>
         </div>
     </div>

--- a/ui/app/common/displaycontrols/patientprofile/views/patientProfile.html
+++ b/ui/app/common/displaycontrols/patientprofile/views/patientProfile.html
@@ -10,7 +10,7 @@
                         </span>
                         <div class="patient-value">
                              <span class="patient-name">
-                                {{::patient.name | titleCase}} ({{::patient.identifier}})</span> -
+                                {{::patient.name | titleCase}} <span ng-if="patient.isDead || patientContext.isDead" style="color:red; font-weight:bold; margin-left: 5px;">(Deceased)</span> ({{::patient.identifier}})</span> -
                              <span class="patient-gender-age" ng-bind-html="::patientAttributeTypes"></span>
                              <span class="patient-estimated-text" ng-if="::patient.birthdateEstimated"> (est.)</span>
                              <span class="patient-birth-time" ng-show="::patient.birthtime">

--- a/ui/app/common/patient-search/views/patientsList.html
+++ b/ui/app/common/patient-search/views/patientsList.html
@@ -69,7 +69,7 @@
                                ng-click="forwardPatient(row, heading)">{{::row[heading.name]}}</a>
                             <div ng-if="::isHeadingOfName(heading.name)" style="min-width: 150px" ng-click="forwardPatient(row)">
                                 <div style="width: 80%;">
-                                    {{::(isHeadingOfDateColumn(heading.name) ? (row[heading.name] | bahmniDate) : row[heading.name])}}
+                                    {{::(isHeadingOfDateColumn(heading.name) ? (row[heading.name] | bahmniDate) : row[heading.name])}} <span ng-if="row.isDead" style="color:red; font-weight:bold; margin-left: 5px;">(Deceased)</span>
                                 </div>
                                 <span class="icons-container">
                                     <i class="ipd-indication fa fa-bed" ng-if="::(row.hasBeenAdmitted===true||row.hasBeenAdmitted==='true')"></i>
@@ -90,7 +90,7 @@
             <ul>
                 <li ng-repeat="patient in search.visiblePatients" class="active-patient" ng-click="forwardPatient(patient)">
                     <img class="smallImages" ng-src="{{::patient.image}}" fallback-src='../images/blank-user.png'>
-                    <div class="patient-name">{{::patient.name}}</div>
+                    <div class="patient-name">{{::patient.name}}<span ng-if="patient.isDead" style="color:red; font-weight:bold; margin-left: 5px;">(Deceased)</span></div>
                     <div ng-if="!preferExtraIdInSearchResults" class="patient-id">{{::patient.identifier}}</div>
                     <div ng-if="preferExtraIdInSearchResults" class="patient-id">{{::patient.extraIdentifier}}</div>
                     <span class="icons-container">

--- a/ui/app/common/patient/header/views/patientSummary.html
+++ b/ui/app/common/patient/header/views/patientSummary.html
@@ -1,6 +1,6 @@
 <div class="patient-details">
     <i class="fa fa-user"></i>
-    <span>{{patient.name}}</span>
+    <span>{{patient.name}}</span><span ng-if="patient.isDead || patientContext.isDead" style="color:red; font-weight:bold; margin-left: 5px;">(Deceased)</span>
     <span>({{patient.identifier}},</span>
     <span>{{patient.gender | gender }},</span>
     <span>{{patient.age}} {{ 'YEARS_LABEL'|translate }})</span>

--- a/ui/app/common/patient/mappers/patientContextMapper.js
+++ b/ui/app/common/patient/mappers/patientContextMapper.js
@@ -27,6 +27,7 @@ Bahmni.PatientContextMapper = function () {
             patientContext.birthdate = parseDate(patient.person.birthdate);
         }
 
+        patientContext.isDead = patient.person.dead || false;
         return patientContext;
     };
 

--- a/ui/app/common/patient/mappers/patientMapper.js
+++ b/ui/app/common/patient/mappers/patientMapper.js
@@ -21,6 +21,7 @@ Bahmni.PatientMapper = function (patientConfig, $rootScope, $translate) {
     this.mapBasic = function (openmrsPatient) {
         var patient = {};
         patient.uuid = openmrsPatient.uuid;
+        patient.isDead = openmrsPatient.person.dead || false;
         patient.givenName = openmrsPatient.person.preferredName.givenName;
         patient.familyName = openmrsPatient.person.preferredName.familyName === null ? '' : openmrsPatient.person.preferredName.familyName;
         patient.name = patient.givenName + ' ' + patient.familyName;

--- a/ui/app/orders/views/header.html
+++ b/ui/app/orders/views/header.html
@@ -2,7 +2,7 @@
     <a ng-href="../clinical/#/default/patient/{{patient.uuid}}/dashboard" title="Back to {{patient.name}}'s Clinical Dashboard">
         <img class="patient-image" ng-src="{{::patient.image}}" fallback-src="../images/blank-user.gif">
         <span class="patient-info">
-            <span class="patient-name" >{{patient.name}} </span>
+            <span class="patient-name" >{{patient.name}} </span><span ng-if="patient.isDead || patientContext.isDead" style="color:red; font-weight:bold; margin-left: 5px;">(Deceased)</span>
             <span class="patient-id">{{patient.identifier}}</span>
         </span>
     </a>

--- a/ui/app/registration/views/visit.html
+++ b/ui/app/registration/views/visit.html
@@ -21,7 +21,7 @@
                                 <label class="control-label" for="patientName">{{ ::'REGISTRATION_LABEL_PATIENT_NAME' | translate}} : </label>
                             </div>
                             <div class="field-value">
-                                <label class="control-label"><strong>{{::patient.name}}</strong></label>
+                                <label class="control-label"><strong>{{::patient.name}}</strong><span ng-if="patient.isDead || patientContext.isDead" style="color:red; font-weight:bold; margin-left: 5px;">(Deceased)</span></label>
                             </div>
                         </div>
                     </section>

--- a/ui/test/unit/common/patient/mappers/patientContextMapper.spec.js
+++ b/ui/test/unit/common/patient/mappers/patientContextMapper.spec.js
@@ -55,7 +55,8 @@ describe('patient context mapper', function () {
             familyName: 'Patient',
             middleName: null,
             gender: 'M',
-            identifier: 'OS1234'
+            identifier: 'OS1234',
+            isDead: false
         };
         expect(patientContextMapper.map(patient)).toEqual(mappedPatient);
     });
@@ -103,7 +104,8 @@ describe('patient context mapper', function () {
             familyName: 'Patient',
             middleName: null,
             gender: 'M',
-            identifier: 'BDH202048'
+            identifier: 'BDH202048',
+            isDead: false
         };
         expect(patientContextMapper.map(patient)).toEqual(mappedPatient);
     })


### PR DESCRIPTION
### Description
**Problem:** 
Currently in Bahmni, when a patient is marked as dead, there is no visual indication on their profile or in the search results to alert the user of their deceased status. 

**Proposed Solution:**
This PR introduces a clear visual indicator for deceased patients across the Bahmni application suite. A bold, red `(Deceased)` tag is now conditionally injected next to the patient's name whenever the `patient.isDead` attribute is true.

**Impact Assessment / Affected Screens:**
This change successfully covers all requirements defined in the JIRA ticket by updating the relevant views and shared display controls:
* **Patient Dashboard & Clinical App:** Covered via `clinicalDashboardHeader.html` and `visitHeader.html`
* **Search Results:** Covered via `patientsList.html` and `recentPatients.html`
* **Registration App:** Covered via Registration `visit.html` and `patientCommon.html`
* **Patient Programs:** Covered via the shared `patientProfile.html` display control
* **Document & Radiology Upload:** Covered via the shared `patientSummary.html` component and `orders/views/header.html`. 

### Testing Evidence

**Screenshots:**

<img width="1423" height="722" alt="Screenshot 2026-07-22 at 10 40 10 AM" src="https://github.com/user-attachments/assets/cc5131b2-29b9-498d-bbf9-d7f4f264a41c" />

<img width="1390" height="634" alt="Screenshot 2026-07-22 at 10 40 28 AM" src="https://github.com/user-attachments/assets/d10f39b9-6913-41c3-bddc-f887d9cac57a" />


### Related JIRA Ticket
[BAH-3425](https://bahmni.atlassian.net/browse/BAH-3425)


[BAH-3425]: https://bahmni.atlassian.net/browse/BAH-3425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ