### PR TITLE
BAH-4847 | Fix bed management home button to navigate to configured homeURL

### DIFF
--- a/ui/app/bedmanagement/app.js
+++ b/ui/app/bedmanagement/app.js
@@ -18,7 +18,7 @@ angular.module('ipd').config(['$stateProvider', '$httpProvider', '$urlRouterProv
     function ($stateProvider, $httpProvider, $urlRouterProvider, $bahmniTranslateProvider, $compileProvider) {
         $urlRouterProvider.otherwise('/home');
 
-        var homeBackLink = {type: "link", name: "Home", value: Bahmni.Common.Constants.homeUrl, accessKey: "h", icon: "fa-home"};
+        var homeBackLink = {type: "link", name: "Home", value: localStorage.getItem('homeUrl') || Bahmni.Common.Constants.homeUrl, accessKey: "h", icon: "fa-home"};
         var admitLink = {type: "state", name: "ADMIT_HOME_KEY", value: "home", accessKey: "a"};
         var bedManagementLink = {type: "state", name: "BED_MANAGEMENT_KEY", value: "bedManagement", accessKey: "b"};
         var navigationLinks = [admitLink, bedManagementLink];


### PR DESCRIPTION
Changed homeBackLink to fetch homeURL from localStorage to be consistent with other apps on Bahmni Clinical