### PR TITLE
BAH-4739 Due to | null condition even rate and additives not filled 

### DIFF
--- a/ui/app/clinical/common/models/drugOrder.js
+++ b/ui/app/clinical/common/models/drugOrder.js
@@ -26,8 +26,8 @@ Bahmni.Clinical.DrugOrder = (function () {
             var dosingInstructions = {};
             dosingInstructions.instructions = drugOrderData.instructions && drugOrderData.instructions;
             dosingInstructions.additionalInstructions = drugOrderData.additionalInstructions;
-            dosingInstructions.rate = drugOrderData.rate || null;
-            dosingInstructions.additives = drugOrderData.additives || null;
+            dosingInstructions.rate = drugOrderData.rate;
+            dosingInstructions.additives = drugOrderData.additives;
             if (drugOrderData.frequencyType === Bahmni.Clinical.Constants.dosingTypes.variable) {
                 dosingInstructions.morningDose = drugOrderData.variableDosingType.morningDose;
                 dosingInstructions.afternoonDose = drugOrderData.variableDosingType.afternoonDose;


### PR DESCRIPTION
https://github.com/cureinternational/openmrs-module-bahmniapps/blob/506f8ef8146cff44d9cf0f0e451e111814ebf06b/ui/app/clinical/common/models/drugOrder.js#L29-L30

In the client, the rate and additives fields are initialized with null. As a result, they are always serialized into the request payload as "rate": null and "additives": null, even when the user has not provided values. If these fields are not populated, they should be omitted from the JSON payload instead of being sent with null values.