### PR TITLE
BAH-4803 | Fix. Log out Bahmni when the OpenMRS session user changes

### DIFF
--- a/ui/app/common/auth/authentication.js
+++ b/ui/app/common/auth/authentication.js
@@ -37,7 +37,7 @@ angular.module('authentication')
             });
         });
     }]).service('sessionService', ['$rootScope', '$http', '$q', '$bahmniCookieStore', 'userService', '$window', function ($rootScope, $http, $q, $bahmniCookieStore, userService, $window) {
-        var sessionResourcePath = Bahmni.Common.Constants.RESTWS_V1 + '/session?v=custom:(uuid)';
+        var sessionResourcePath = Bahmni.Common.Constants.RESTWS_V1 + '/session?v=custom:(uuid,user:(username))';
 
         var getAuthFromServer = function (username, password, otp) {
             var btoa = otp ? username + ':' + password + ':' + otp : username + ':' + password;
@@ -146,29 +146,42 @@ angular.module('authentication')
                 });
                 return deferrable.promise;
             }
-            userService.getUser(currentUser).then(function (data) {
-                userService.getProviderForUser(data.results[0].uuid).then(function (providers) {
-                    if (!_.isEmpty(providers.results) && hasAnyActiveProvider(providers.results)) {
-                        $rootScope.currentUser = new Bahmni.Auth.User(data.results[0]);
-                        $rootScope.currentUser.provider = providers.results[0];
-                        var location = $bahmniCookieStore.get(Bahmni.Common.Constants.locationCookieName);
-                        if (location) {
-                            $rootScope.currentUser.currentLocation = location.name;
+            self.get().then(function (response) {
+                var sessionUser = response.data && response.data.user;
+                if (!sessionUser || !sessionUser.username || sessionUser.username.toLowerCase() !== currentUser.toLowerCase()) {
+                    self.destroy().finally(function () {
+                        $rootScope.$broadcast('event:auth-loginRequired');
+                        deferrable.reject("Session user changed. Please login again.");
+                    });
+                    return;
+                }
+                userService.getUser(currentUser).then(function (data) {
+                    userService.getProviderForUser(data.results[0].uuid).then(function (providers) {
+                        if (!_.isEmpty(providers.results) && hasAnyActiveProvider(providers.results)) {
+                            $rootScope.currentUser = new Bahmni.Auth.User(data.results[0]);
+                            $rootScope.currentUser.provider = providers.results[0];
+                            var location = $bahmniCookieStore.get(Bahmni.Common.Constants.locationCookieName);
+                            if (location) {
+                                $rootScope.currentUser.currentLocation = location.name;
+                            }
+                            $rootScope.$broadcast('event:user-credentialsLoaded', data.results[0]);
+                            deferrable.resolve(data.results[0]);
+                        } else {
+                            self.destroy();
+                            deferrable.reject("YOU_HAVE_NOT_BEEN_SETUP_PROVIDER");
                         }
-                        $rootScope.$broadcast('event:user-credentialsLoaded', data.results[0]);
-                        deferrable.resolve(data.results[0]);
-                    } else {
-                        self.destroy();
-                        deferrable.reject("YOU_HAVE_NOT_BEEN_SETUP_PROVIDER");
-                    }
-                },
-               function () {
-                   self.destroy();
-                   deferrable.reject("COULD_NOT_GET_PROVIDER");
-               });
+                    },
+                   function () {
+                       self.destroy();
+                       deferrable.reject("COULD_NOT_GET_PROVIDER");
+                   });
+                }, function () {
+                    self.destroy();
+                    deferrable.reject('Could not get roles for the current user.');
+                });
             }, function () {
                 self.destroy();
-                deferrable.reject('Could not get roles for the current user.');
+                deferrable.reject('Could not get the current session.');
             });
             return deferrable.promise;
         };

--- a/ui/test/unit/common/auth/authentication.spec.js
+++ b/ui/test/unit/common/auth/authentication.spec.js
@@ -49,14 +49,100 @@ describe("Authentication", function () {
 
 
     describe("Should show error message ", function () {
-        it("to the user when user doesn't select the location for the first time login", inject(['sessionService', '$rootScope', function (sessionService, $rootScope) {
+        it("to the user when user doesn't select the location for the first time login", inject(['sessionService', '$rootScope', '$http', function (sessionService, $rootScope, $http) {
             var deferrable = jasmine.createSpyObj('deferrable', ['reject']);
             $q.defer.and.returnValue(deferrable);
             spyOn(sessionService, 'destroy');
+            $bahmniCookieStore.get.and.callFake(function (cookieName) {
+                if (cookieName == Bahmni.Common.Constants.currentUser) {
+                    return 'superman';
+                }
+            });
+            var fakeHttpGetPromise = {
+                then: function (success, failure) {
+                    success({data: {uuid: 'some-uuid', user: {username: 'superman'}}});
+                }
+            };
+            spyOn($http, 'get').and.returnValue(fakeHttpGetPromise);
 
             sessionService.loadCredentials();
 
             expect(deferrable.reject).toHaveBeenCalledWith("YOU_HAVE_NOT_BEEN_SETUP_PROVIDER");
+        }]));
+    });
+
+    describe("loadCredentials", function () {
+        it("should proceed to fetch the user when the cookie username matches the session username case-insensitively", inject(['sessionService', '$rootScope', '$http', function (sessionService, $rootScope, $http) {
+            var deferrable = jasmine.createSpyObj('deferrable', ['reject', 'resolve']);
+            $q.defer.and.returnValue(deferrable);
+            spyOn(sessionService, 'destroy');
+            spyOn($rootScope, '$broadcast');
+            $bahmniCookieStore.get.and.callFake(function (cookieName) {
+                if (cookieName == Bahmni.Common.Constants.currentUser) {
+                    return 'Superman';
+                }
+            });
+            var fakeHttpGetPromise = {
+                then: function (success, failure) {
+                    success({data: {uuid: 'some-uuid', user: {username: 'superman'}}});
+                }
+            };
+            spyOn($http, 'get').and.returnValue(fakeHttpGetPromise);
+
+            sessionService.loadCredentials();
+
+            expect(userService.getUser).toHaveBeenCalledWith('Superman');
+            expect($rootScope.$broadcast).not.toHaveBeenCalledWith('event:auth-loginRequired');
+        }]));
+
+        it("should logout when the cookie username does not match the session username", inject(['sessionService', '$rootScope', '$http', function (sessionService, $rootScope, $http) {
+            var deferrable = jasmine.createSpyObj('deferrable', ['reject', 'resolve']);
+            $q.defer.and.returnValue(deferrable);
+            spyOn(sessionService, 'destroy').and.returnValue(specUtil.createFakePromise());
+            spyOn($rootScope, '$broadcast');
+            $bahmniCookieStore.get.and.callFake(function (cookieName) {
+                if (cookieName == Bahmni.Common.Constants.currentUser) {
+                    return 'superman';
+                }
+            });
+            var fakeHttpGetPromise = {
+                then: function (success, failure) {
+                    success({data: {uuid: 'some-uuid', user: {username: 'registration'}}});
+                }
+            };
+            spyOn($http, 'get').and.returnValue(fakeHttpGetPromise);
+
+            sessionService.loadCredentials();
+
+            expect(userService.getUser).not.toHaveBeenCalled();
+            expect(sessionService.destroy).toHaveBeenCalled();
+            expect($rootScope.$broadcast).toHaveBeenCalledWith('event:auth-loginRequired');
+            expect(deferrable.reject).toHaveBeenCalledWith("Session user changed. Please login again.");
+        }]));
+
+        it("should logout when the session has no user", inject(['sessionService', '$rootScope', '$http', function (sessionService, $rootScope, $http) {
+            var deferrable = jasmine.createSpyObj('deferrable', ['reject', 'resolve']);
+            $q.defer.and.returnValue(deferrable);
+            spyOn(sessionService, 'destroy').and.returnValue(specUtil.createFakePromise());
+            spyOn($rootScope, '$broadcast');
+            $bahmniCookieStore.get.and.callFake(function (cookieName) {
+                if (cookieName == Bahmni.Common.Constants.currentUser) {
+                    return 'superman';
+                }
+            });
+            var fakeHttpGetPromise = {
+                then: function (success, failure) {
+                    success({data: {uuid: 'some-uuid'}});
+                }
+            };
+            spyOn($http, 'get').and.returnValue(fakeHttpGetPromise);
+
+            sessionService.loadCredentials();
+
+            expect(userService.getUser).not.toHaveBeenCalled();
+            expect(sessionService.destroy).toHaveBeenCalled();
+            expect($rootScope.$broadcast).toHaveBeenCalledWith('event:auth-loginRequired');
+            expect(deferrable.reject).toHaveBeenCalledWith("Session user changed. Please login again.");
         }]));
     });
 
@@ -178,7 +264,7 @@ describe("Authentication", function () {
 
             sessionService.resendOTP("userName", "password");
 
-            expect($http.get).toHaveBeenCalledWith('/openmrs/ws/rest/v1/session?v=custom:(uuid)&resendOTP=true', {
+            expect($http.get).toHaveBeenCalledWith('/openmrs/ws/rest/v1/session?v=custom:(uuid,user:(username))&resendOTP=true', {
                 headers: {Authorization: 'Basic dXNlck5hbWU6cGFzc3dvcmQ='},
                 cache: false
             })


### PR DESCRIPTION
Bahmni trusted the bahmni.user cookie for identity while authorization came from the live OpenMRS server session. Logging into OpenMRS directly as a different user (without going through Bahmni) left the cookie stale: Bahmni kept displaying the old username while actually operating with the new user's privileges.

sessionService.loadCredentials() (called on every app's init, including home) now fetches the live session and compares its user.username against the bahmni.user cookie, case-insensitively. On mismatch, or if the session has no user at all, Bahmni logs out via the existing destroy() -> event:auth-loginRequired path, same as the "no cookie" case.

sessionResourcePath is widened to ?v=custom:(uuid,user:(username)) so the session response carries the username needed for the comparison.